### PR TITLE
Set display mode of checboxes to block

### DIFF
--- a/docs/base/forms.md
+++ b/docs/base/forms.md
@@ -99,15 +99,39 @@ To disabled a text input you can set the property `disabled="true"`.
 
 ## Checkbox
 
-To use a normal inline checkbox use the class name of `.checkbox`.
+To use a normal checkbox use the class name of `.checkbox`.
 
-<label class="form-field checkbox">
+<label class="checkbox">
+  <input class="checkbox__input" type="checkbox" />
+  <span class="checkbox__label">A checkbox</span>
+</label>
+
+<label class="checkbox">
   <input class="checkbox__input" type="checkbox" />
   <span class="checkbox__label">A checkbox</span>
 </label>
 
 ```html
-<label class="form-field checkbox">
+<label class="checkbox">
+  <input class="checkbox__input" type="checkbox" />
+  <span class="checkbox__label">A checkbox</span>
+</label>
+```
+
+You can make checkboxes inline with `.checkbox--inline`.
+
+<label class="checkbox checkbox--inline">
+  <input class="checkbox__input" type="checkbox" />
+  <span class="checkbox__label">A checkbox</span>
+</label>
+
+<label class="checkbox checkbox--inline margin1--left">
+  <input class="checkbox__input" type="checkbox" />
+  <span class="checkbox__label">A checkbox</span>
+</label>
+
+```html
+<label class="checkbox checkbox--inline">
   <input class="checkbox__input" type="checkbox" />
   <span class="checkbox__label">A checkbox</span>
 </label>

--- a/styles/pup/base/_forms.scss
+++ b/styles/pup/base/_forms.scss
@@ -67,6 +67,14 @@ textarea {
   min-height: $spacing-unit * 4;
 }
 
+.checkbox {
+  display: block;
+}
+
+.checkbox--inline {
+  display: inline-block;
+}
+
 .checkbox__input,
 .checkbox__label,
 .radio__input,


### PR DESCRIPTION
This will allow us to set vertical margins on checkboxes.

Also adds a `.checkbox--inline` modifier that will allow us to render checkboxes as inline-blocks.

<img width="518" alt="screen shot 2016-10-27 at 5 41 29 pm" src="https://cloud.githubusercontent.com/assets/6979137/19786595/bd6afec4-9c6c-11e6-9c63-2ab8ced13789.png">

/cc @underdogio/engineering 