### PR TITLE
Set type spacing to 1 spacing unit

### DIFF
--- a/styles/pup/base/_typography.scss
+++ b/styles/pup/base/_typography.scss
@@ -4,10 +4,8 @@ h2,
 .h2,
 h3,
 .h3,
-h4,
-.h4,
 p {
-  margin-bottom: spacing(half);
+  margin-bottom: spacing(1);
   margin-top: 0;
 }
 
@@ -45,6 +43,7 @@ h4,
   color: $color-text-light;
   font-size: font-size(-1);
   font-weight: font-weight(bold);
+  margin-bottom: spacing(half);
 }
 
 p {


### PR DESCRIPTION
Increases bottom margin of large headings and paragraphs to 1 spacing unit (21px). This is similar to what we have currently in Company Dashboard (22px).

*Before*

<img width="1074" alt="typography-before" src="https://cloud.githubusercontent.com/assets/6979137/19786717/51a9b846-9c6d-11e6-8d81-c195bdf826a9.png">

*After*

<img width="1091" alt="typography-after" src="https://cloud.githubusercontent.com/assets/6979137/19786712/4c613986-9c6d-11e6-8870-1c37fb09aae5.png">

/cc @underdogio/design @underdogio/engineering 