### PR TITLE
Decrease aside layout sidebar width and padding

### DIFF
--- a/styles/pup/layout/_aside-layout.scss
+++ b/styles/pup/layout/_aside-layout.scss
@@ -2,7 +2,8 @@
 // but the content is allowed to scroll independently. Works best when the parent container has a set height.
 
 $aside-layout-padding: spacing(2);
-$aside-layout-sidebar-width: 20%;
+$aside-layout-padding-medium-and-down: spacing(1);
+$aside-layout-sidebar-width: percentage(2 / $grid-num-columns);
 $aside-layout-sidebar-fixed-width: 26rem;
 
 .aside-layout {
@@ -14,6 +15,10 @@ $aside-layout-sidebar-fixed-width: 26rem;
 .aside-layout__sidebar,
 .aside-layout__content {
   padding: $aside-layout-padding;
+
+  @include media-query('medium-and-down') {
+    padding: $aside-layout-padding-medium-and-down;
+  }
 }
 
 .aside-layout__sidebar {


### PR DESCRIPTION
Decreases the width of the aside-layout sidebar (~16.6667%) to be more inline with what we have now in CompD (16%).

Also decreases the padding to accommodate the smaller width (since we are using `box-sizing: border-box`).

*Before - All screen widths*

<img width="737" alt="aside-layout-padding-before" src="https://cloud.githubusercontent.com/assets/6979137/19788231/2457a0e4-9c75-11e6-93c0-ed2c189cdc19.png">

*After - Large*

<img width="686" alt="aside-layout-padding-after-large" src="https://cloud.githubusercontent.com/assets/6979137/19788211/10479de8-9c75-11e6-88ba-7eb86c0aff19.png">

*After - Medium and down*

<img width="415" alt="aside-layout-padding-after-medium-down" src="https://cloud.githubusercontent.com/assets/6979137/19788208/0ddfaeb0-9c75-11e6-914c-a75a28ed71c9.png">


/cc @underdogio/engineering 