### PR TITLE
s/btn-group__content/btn-group__container

### DIFF
--- a/styles/pup/components/_btn.scss
+++ b/styles/pup/components/_btn.scss
@@ -126,7 +126,7 @@
 }
 
 // Have buttons take up full width of .btn-group container
-.btn-group__content {
+.btn-group__container {
   display: flex;
 
   // Allow each button to change width as needed


### PR DESCRIPTION
Updates class name for `.btn-group__container` to class that is being used in our markup.

*Before*

<img width="264" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/19812217/a78224fc-9d02-11e6-9c5f-c3b6216b65d5.png">

*After*

<img width="533" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/19812221/aa04a7f4-9d02-11e6-898e-3b7b2195d9df.png">

/cc @underdogio/engineering 