### PR TITLE
Darken disabled input border color

### DIFF
--- a/styles/pup/base/_forms.scss
+++ b/styles/pup/base/_forms.scss
@@ -59,7 +59,7 @@ textarea {
   &:focus,
   &:hover {
     background: $color-gray-xf3;
-    border-color: $color-border-light;
+    border-color: $color-border-dark;
   }
 }
 


### PR DESCRIPTION
title reveals all

*Before*

<img width="1054" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/19812409/61e40298-9d03-11e6-849c-f63607d11647.png">

*After*

<img width="1095" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/19812415/64e94caa-9d03-11e6-95c6-c33af2429705.png">

/cc @underdogio/engineering 