### PR TITLE
Alert links should inherit their color

### DIFF
--- a/docs/components/alerts.md
+++ b/docs/components/alerts.md
@@ -22,28 +22,46 @@ Alerts are full width blocks that can be used to show status messages.
 Alerts can have a state of `.alert--error` or `.alert--success`.
 
 <div class="alert alert--error">
-  This is an error message
+  <div>
+    This is an error message
+    <a href="#">with a link</a>
+  </div>
 </div>
 
 <div class="alert alert--success">
-  This is a success message
+  <div>
+    This is a success message
+    <a href="#">with a link</a>
+  </div>
 </div>
 
 <div class="alert alert--info">
-  This is an info message
+  <div>
+    This is an info message
+    <a href="#">with a link</a>
+  </div>
 </div>
 
 ```html
 <div class="alert alert--error">
-  This is an error message
+  <div>
+    This is an error message
+    <a href="#">with a link</a>
+  </div>
 </div>
 
 <div class="alert alert--success">
-  This is a success message
+  <div>
+    This is a success message
+    <a href="#">with a link</a>
+  </div>
 </div>
 
 <div class="alert alert--info">
-  This is an info message
+  <div>
+    This is an info message
+    <a href="#">with a link</a>
+  </div>
 </div>
 ```
 

--- a/styles/pup/components/_alert.scss
+++ b/styles/pup/components/_alert.scss
@@ -6,6 +6,11 @@
   font-weight: font-weight(bold);
   justify-content: space-between;
   padding: spacing(half) spacing(1);
+
+  a,
+  .text-link {
+    color: inherit;
+  }
 }
 
 .alert--success {


### PR DESCRIPTION
Updating the text color for links inside of an `alert--error` to also be white... otherwise they look really weird.

![image](https://cloud.githubusercontent.com/assets/1320353/19904537/64e82eda-a049-11e6-8601-3b684f823e22.png)


/cc @underdogio/engineering 