### PR TITLE
Fix alignment of superscript elements

### DIFF
--- a/docs/base/000-typography.md
+++ b/docs/base/000-typography.md
@@ -130,3 +130,23 @@ You can apply a heading style to a non-header element with a class.
 ```html
 <span class="h3">A span with h3 styling</span>
 ```
+
+## Superscript
+
+<p>
+  Some text with a superscript <sup>TM</sup>
+</p>
+
+<h1>
+  Heading with a superscript <sup class="h4 color--green font-weight--bold">Beta</sup>
+</h1>
+
+```html
+<p>
+  Some text with a superscript <sup>TM</sup>
+</p>
+
+<h1>
+  Heading with a superscript <sup class="h4 color--green font-weight--bold">Beta</sup>
+</h1>
+```

--- a/styles/pup/base/_typography.scss
+++ b/styles/pup/base/_typography.scss
@@ -52,3 +52,7 @@ p {
     margin-bottom: 0;
   }
 }
+
+sup {
+  vertical-align: super;
+}


### PR DESCRIPTION
Changes the vertical alignment of `<sup>` elements from `baseline` to `super`.

Why isn't this the default ?! 🤔 

<img width="1094" alt="screen shot 2016-11-02 at 12 08 04 pm" src="https://cloud.githubusercontent.com/assets/6979137/19936824/500740ee-a0f5-11e6-8add-9e69f8c67461.png">

/cc @underdogio/engineering 