### PR TITLE
Add hyphens to preserve-whitespace helper for browsers that support it

### DIFF
--- a/docs/base/helpers.md
+++ b/docs/base/helpers.md
@@ -159,6 +159,16 @@ Capture elements that have a `position` set to `absolute` by applying the class
 </div>
 ```
 
+## `.preserve-whitespace`
+
+Use to preserve line breaks within a block of text.
+
+<p class="preserve-whitespace" style="width: 200px;">
+  Explicabo sunt quis cupiditate autem fusce feugiat interdum sit duis.
+
+  Mi quisque ullamco, iusto consequuntur accumsan maiores turpis atque! Consequatsuscipitpellentesque. Vivamus lacus laborum.
+</p>
+
 ## Strikethrough
 
 Allows you to display a strikethrough on top of an element.

--- a/styles/pup/mixins/_preserve-whitespace.scss
+++ b/styles/pup/mixins/_preserve-whitespace.scss
@@ -1,4 +1,8 @@
 @mixin preserve-whitespace {
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  hyphens: auto;
   white-space: pre-line;
-  word-break: break-all;
+  word-break: break-word;
+  word-wrap: break-word;
 }


### PR DESCRIPTION
Closes #24 

Adds hyphenation to the `preserve-whitespace` mixin for browsers that support it.

Also prevents words from overflowing their container by forcing them to break as necessary (see 'Consequatsuscipitpellentesque' towards the bottom):

<img width="237" alt="screen shot 2016-11-02 at 6 10 52 pm" src="https://cloud.githubusercontent.com/assets/6979137/19949589/e6aabfca-a128-11e6-9b30-c6a0942a6189.png">

/cc @underdogio/engineering 