### PR TITLE
Fix class toggle component to only toggle class for intended target

### DIFF
--- a/scripts/components/class-toggle.js
+++ b/scripts/components/class-toggle.js
@@ -1,5 +1,6 @@
 function createClassToggle (element) {
-  var target = document.querySelectorAll(element.dataset.target)[0];
+  var targetSelector = element.dataset.target;
+  var target = document.querySelector(targetSelector);
 
   if (!target) {
     return false;
@@ -8,7 +9,23 @@ function createClassToggle (element) {
   var classToToggle = element.dataset.class;
 
   document.addEventListener('click', function (e) {
-    if (e.target.classList.contains('js-class-toggle') || e.target.closest('.js-class-toggle')) {
+    var eventTarget = e.target;
+
+    // Check if an element with the js-class-toggle class was clicked
+    var clickedElement;
+    if (eventTarget.classList.contains('js-class-toggle')) {
+      clickedElement = eventTarget;
+    } else {
+      // Check if the clicked element is a child of a toggle element
+      // closest will return null if no parent element is found
+      clickedElement = eventTarget.closest('.js-class-toggle');
+    }
+
+    // Check if the element that was clicked has the same target as element
+    var didMatchTarget = clickedElement && clickedElement.dataset.target === targetSelector;
+
+    // Toggle class on target element if targets match up
+    if (didMatchTarget) {
       e.preventDefault();
       target.classList.toggle(classToToggle);
     }


### PR DESCRIPTION
There's a handy JS component called `.js-class-toggle` that lets you toggle a CSS class for an element from markup.

It works like this:

```html
<!-- Clicking this button will toggle the "beep--boop" class on the div -->
<button class="js-class-toggle" data-target="#someTarget" data-class="beep---boop">Bop it</button>

<div id="someTarget" class="beep">Twist it</div>
```

There was one small problem with it, which is that it will toggle all elements with the required `.js-class-toggle`, even if that element wasn't the intended target.

I hope that explanation made sense...

/cc @underdogio/engineering 