### PR TITLE
Add styles for fixed alerts

### DIFF
--- a/docs/components/alerts.md
+++ b/docs/components/alerts.md
@@ -21,21 +21,21 @@ Alerts are full width blocks that can be used to show status messages.
 
 Alerts can have a state of `.alert--error` or `.alert--success`.
 
-<div class="alert alert--error">
+<div class="alert alert--error margin1--bottom">
   <div>
     This is an error message
     <a href="#">with a link</a>
   </div>
 </div>
 
-<div class="alert alert--success">
+<div class="alert alert--success margin1--bottom">
   <div>
     This is a success message
     <a href="#">with a link</a>
   </div>
 </div>
 
-<div class="alert alert--info">
+<div class="alert alert--info margin1--bottom">
   <div>
     This is an info message
     <a href="#">with a link</a>
@@ -83,4 +83,71 @@ Alerts can optionally contain a `.alertclose` which is placed at the far right o
     <span class="icon icon-close" aria-label="close" />
   </button>
 </div>
+```
+
+## Alert list
+
+If you need to render multiple alerts in a list, you can use the `.alert-list` component.
+
+You can fix alert lists to the top of the screen by applying the `.alert-list--fixed`
+modifier class.
+
+<button class="btn btn--primary js-class-toggle" data-target="#alertList" data-class="alert-list--fixed">Toggle `.alert-list--fixed` class</button>
+
+<div class="margin1--bottom"></div>
+
+<ul id="alertList" class="alert-list">
+  <li class="alert-list__item">
+    <div class="alert alert--error">
+      <div>
+        This is an error message
+        <a href="#">with a link</a>
+      </div>
+    </div>
+  </li>
+  <li class="alert-list__item">
+    <div class="alert alert--success">
+      <div>
+        This is a success message
+        <a href="#">with a link</a>
+      </div>
+    </div>
+  </li>
+  <li class="alert-list__item">
+    <div class="alert alert--info">
+      <div>
+        This is an info message
+        <a href="#">with a link</a>
+      </div>
+    </div>
+  </li>
+</ul>
+
+```html
+<ul class="alert-list">
+  <li class="alert-list__item">
+    <div class="alert alert--error">
+      <div>
+        This is an error message
+        <a href="#">with a link</a>
+      </div>
+    </div>
+  </li>
+  <li class="alert-list__item">
+    <div class="alert alert--success">
+      <div>
+        This is a success message
+        <a href="#">with a link</a>
+      </div>
+    </div>
+  </li>
+  <li class="alert-list__item">
+    <div class="alert alert--info">
+      <div>
+        This is an info message
+        <a href="#">with a link</a>
+      </div>
+    </div>
+  </li>
+</ul>
 ```

--- a/styles/pup/_pup.scss
+++ b/styles/pup/_pup.scss
@@ -19,6 +19,7 @@
 @import 'base/typography';
 
 @import 'components/alert';
+@import 'components/alert-list';
 @import 'components/block-label';
 @import 'components/btn';
 @import 'components/carousel';

--- a/styles/pup/components/_alert-list.scss
+++ b/styles/pup/components/_alert-list.scss
@@ -1,0 +1,18 @@
+.alert-list {
+  width: 100%;
+}
+
+.alert-list--fixed {
+  left: 50%;
+  max-width: $measure;
+  padding-left: spacing(half);
+  padding-right: spacing(half);
+  position: fixed;
+  top: spacing(2);
+  transform: translateX(-50%);
+}
+
+.alert-list__item {
+  display: block;
+  margin-bottom: spacing(half);
+}

--- a/styles/pup/components/_alert.scss
+++ b/styles/pup/components/_alert.scss
@@ -1,7 +1,10 @@
 .alert {
   align-items: center;
-  background: $color-gray-xdc;
-  color: $color-text-dark;
+  background: $color-gray-xf3;
+  border: 1px solid $color-border-dark;
+  border-radius: $border-radius;
+  box-shadow: $box-shadow-light;
+  color: $color-text;
   display: flex;
   font-weight: font-weight(bold);
   justify-content: space-between;
@@ -14,13 +17,11 @@
 }
 
 .alert--success {
-  background: $color-dark-green;
-  color: $color-white;
+  background: $color-light-green;
 }
 
 .alert--info {
   background: $color-light-blue;
-  color: $color-text-dark;
 }
 
 .alert--error {

--- a/styles/pup/components/_modal.scss
+++ b/styles/pup/components/_modal.scss
@@ -30,7 +30,7 @@
 .modal__content {
   background: $color-white;
   border-radius: $border-radius;
-  box-shadow: $box-shadow;
+  box-shadow: $box-shadow-dark;
   left: 50%;
   max-width: $measure / 2;
   padding: spacing(1);

--- a/styles/pup/variables/_box-shadow.scss
+++ b/styles/pup/variables/_box-shadow.scss
@@ -1,3 +1,4 @@
 @import 'colors';
 
-$box-shadow: 0 1rem 2rem 0 $color-semi-transparent-black;
+$box-shadow-dark: 0 1rem 2rem 0 $color-semi-transparent-black;
+$box-shadow-light: 0 0.15rem 0.15rem 0 $color-semi-transparent-black;

--- a/styles/pup/variables/_colors.scss
+++ b/styles/pup/variables/_colors.scss
@@ -29,7 +29,7 @@ $color-google-red: #DC4E41;
 $color-linkedin-blue: #2476B9;
 
 // Transparent colors
-$color-semi-transparent-black: rgba($color-black, 0.25);
+$color-semi-transparent-black: rgba($color-black, 0.15);
 $color-semi-transparent-blue: rgba($color-blue, 0.05);
 
 // UI colors

--- a/styles/pup/variables/_typography.scss
+++ b/styles/pup/variables/_typography.scss
@@ -43,4 +43,4 @@ $line-height: (
   @return map-get($line-height, $key);
 }
 
-$measure: 60rem;
+$measure: 40rem;


### PR DESCRIPTION
Makes some tweaks to our alert style:

<img width="1101" alt="screen shot 2016-11-09 at 4 34 09 pm" src="https://cloud.githubusercontent.com/assets/6979137/20155548/5fafbcf6-a69a-11e6-9cfd-b250ef1604c8.png">

Also adds an `.alert-list` component that can be used to display a list of alerts that is fixed to the top of the screen:

*Wide viewport*

<img width="1680" alt="screen shot 2016-11-09 at 4 34 40 pm" src="https://cloud.githubusercontent.com/assets/6979137/20155574/76211642-a69a-11e6-8054-4392139d7bb6.png">

*Narrow viewport*

<img width="470" alt="screen shot 2016-11-09 at 4 37 15 pm" src="https://cloud.githubusercontent.com/assets/6979137/20155642/ce611424-a69a-11e6-83cd-be84525e5a3c.png">

/cc @underdogio/design @underdogio/engineering 