### PR TITLE
Add variable for a wider measure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "underdog-pup",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "config": {
     "iconFontName": "underdogio-icons"
   },

--- a/styles/pup/components/_hero.scss
+++ b/styles/pup/components/_hero.scss
@@ -1,3 +1,5 @@
+$hero-max-width: $measure-wide;
+
 .hero {
   @include transition(min-height);
   display: flex;
@@ -10,14 +12,14 @@
 .hero__container {
   margin-left: auto;
   margin-right: auto;
-  max-width: $measure;
+  max-width: $hero-max-width;
   padding-bottom: spacing(2);
   padding-top: spacing(2);
 }
 
 .hero__section {
   margin: 0 auto spacing(1);
-  max-width: $measure * 0.75;
+  max-width: $hero-max-width * 0.75;
 
   &:last-child {
     margin-bottom: 0;

--- a/styles/pup/layout/_longform.scss
+++ b/styles/pup/layout/_longform.scss
@@ -2,7 +2,7 @@ $longform-col-padding: spacing(3);
 
 .longform {
   @include clearfix;
-  max-width: $measure;
+  max-width: $measure-wide;
 }
 
 .longform__col {

--- a/styles/pup/variables/_typography.scss
+++ b/styles/pup/variables/_typography.scss
@@ -44,3 +44,4 @@ $line-height: (
 }
 
 $measure: 40rem;
+$measure-wide: 60rem;


### PR DESCRIPTION
**Depends on #32**

In #30 the value of the `$measure` variable was decreased from `60rem` to `40rem`, which makes  some components a little too narrow. This PR adds a `$measure-wide` variable for a max width of `60rem`, and the components that are currently using the `$measure / 40rem` variable (except for the `.alert-list`) have been updated to use `$measure-wide`.

*Hero*

<img width="1216" alt="screen shot 2016-11-10 at 1 56 28 pm" src="https://cloud.githubusercontent.com/assets/6979137/20190087/03c059fa-a74e-11e6-8868-0ba57c857591.png">

*Longform*

<img width="910" alt="screen shot 2016-11-10 at 1 56 19 pm" src="https://cloud.githubusercontent.com/assets/6979137/20190089/06419284-a74e-11e6-9eb2-0f22f7d380f6.png">

/cc @underdogio/engineering 