### PR TITLE
Add Dockerfile for deploys

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+node_modules
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM mhart/alpine-node:6.9.1
+
+RUN apk add --no-cache python g++ make
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+ARG NODE_ENV
+ENV NODE_ENV $NODE_ENV
+COPY package.json /usr/src/app/
+RUN npm install
+COPY . /usr/src/app
+RUN npm run build
+
+EXPOSE 9008
+CMD [ "npm", "start" ]


### PR DESCRIPTION
\0/

This `Dockerfile` will be used for deploys more so than local development. Maybe in the future we can take a look at using `docker-compose` or something here for this for dev, but for now... deploys.

/cc @underdogio/engineering 