### PR TITLE
Release v1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "underdog-pup",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "config": {
     "iconFontName": "underdogio-icons"
   },


### PR DESCRIPTION
Includes wider `.longform` and `.hero`.

This has not been published to npm yet.

/cc @underdogio/engineering 