### PR TITLE
Prevent text from wrapping within dropdowns and tooltips

### DIFF
--- a/styles/pup/components/_dropdown.scss
+++ b/styles/pup/components/_dropdown.scss
@@ -19,6 +19,7 @@ $dropdown-triangle-size: 1rem;
   right: 0;
   text-align: right;
   top: 50%;
+  white-space: pre;
   width: 16rem;
   z-index: layer(dropdowns);
 

--- a/styles/pup/components/_tooltip.scss
+++ b/styles/pup/components/_tooltip.scss
@@ -42,6 +42,7 @@ $tooltip-triangle-size: 10px;
     position: absolute;
     top: 100%;
     transform: translateX(-50%);
+    white-space: pre;
   }
 
   &:hover {


### PR DESCRIPTION
This will allow dropdowns and tooltips to extend past the width of their parent containers.

**Dropdowns**

*Before*

<img width="259" alt="dropdowns - before" src="https://cloud.githubusercontent.com/assets/6979137/20272005/96160d40-aa5a-11e6-8344-47eb9cc2a34e.png">

*After*

<img width="388" alt="dropdowns - after" src="https://cloud.githubusercontent.com/assets/6979137/20272014/9a5789ec-aa5a-11e6-8ba3-fb99a1be5394.png">

**Tooltips**

*Before*

<img width="96" alt="tooltips - before" src="https://cloud.githubusercontent.com/assets/6979137/20272016/a026090c-aa5a-11e6-8304-4460629318ba.png">

*After*

<img width="248" alt="tooltips - after" src="https://cloud.githubusercontent.com/assets/6979137/20272024/a44fc644-aa5a-11e6-84bc-0f5a5217dc24.png">

/cc @underdogio/engineering 