### PR TITLE
Increase modal content width

### DIFF
--- a/styles/pup/components/_modal.scss
+++ b/styles/pup/components/_modal.scss
@@ -32,7 +32,7 @@
   border-radius: $border-radius;
   box-shadow: $box-shadow-dark;
   left: 50%;
-  max-width: $measure / 2;
+  max-width: $measure-wide / 2;
   padding: spacing(1);
   position: relative;
   top: 50%;


### PR DESCRIPTION
Sets max-width of modal back to `30rem`:

<img width="1139" alt="screen shot 2016-11-14 at 1 22 51 pm" src="https://cloud.githubusercontent.com/assets/6979137/20277190/8f48b3d8-aa6d-11e6-971c-c6902514a3d3.png">

/cc @underdogio/engineering 