### PR TITLE
Prevent page header from getting too wide

### DIFF
--- a/styles/pup/components/_page-header.scss
+++ b/styles/pup/components/_page-header.scss
@@ -3,6 +3,7 @@ $page-header-spacing: spacing(1);
 .page-header {
   margin-bottom: $page-header-spacing;
   margin-top: $page-header-spacing;
+  max-width: $measure-wide;
 }
 
 .page-header__title {


### PR DESCRIPTION
*Before*

<img width="1680" alt="screen shot 2016-11-14 at 1 26 42 pm" src="https://cloud.githubusercontent.com/assets/6979137/20277379/405fdb92-aa6e-11e6-916b-f73da4918125.png">

*After*

<img width="1680" alt="screen shot 2016-11-14 at 1 27 13 pm" src="https://cloud.githubusercontent.com/assets/6979137/20277375/3dc9d022-aa6e-11e6-9b97-bc63cde391d7.png">

/cc @underdogio/engineering 