### PR TITLE
Fix overlapping in step-indicator

### DIFF
--- a/styles/pup/components/_step-indicator.scss
+++ b/styles/pup/components/_step-indicator.scss
@@ -21,7 +21,6 @@ $step-indicator-orb-size: 2rem;
   position: relative;
   text-align: center;
   vertical-align: middle;
-  z-index: layer(base);
 
   &:after {
     background-color: $step-indicator-color-non-active;


### PR DESCRIPTION
Fixes this weird issue (zoom in to second orb to get a better look)

*Before*

<img width="304" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/20277593/2c71b5e6-aa6f-11e6-953f-213960e9685a.png">

*After*

<img width="265" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/20277588/29c66c88-aa6f-11e6-9c4c-82526d5000c4.png">

/cc @underdogio/engineering 