### PR TITLE
Thicken header link border

### DIFF
--- a/styles/pup/components/_header.scss
+++ b/styles/pup/components/_header.scss
@@ -33,7 +33,7 @@
     background: $color-gray-xdc;
     content: '';
     display: block;
-    height: 0.1rem;
+    height: $border-width-thick;
     left: 0;
     opacity: 0;
     position: absolute;


### PR DESCRIPTION
Changes the height of the border in header links to 2px, which is what we have in joinfetch right now.

<img width="127" alt="screen shot 2016-11-15 at 11 45 49 am" src="https://cloud.githubusercontent.com/assets/6979137/20314704/1667adcc-ab29-11e6-9def-985eace32ddd.png">

/cc @underdogio/engineering 