### PR TITLE
Decrease promo header font size to about 22px

### DIFF
--- a/styles/pup/components/_promo.scss
+++ b/styles/pup/components/_promo.scss
@@ -1,6 +1,6 @@
 .promo__header {
   color: $color-text;
-  font-size: font-size(3);
+  font-size: font-size(2);
   font-weight: font-weight(bold);
   margin-bottom: spacing(half);
 }


### PR DESCRIPTION
This will prevent promo headers (in use just on joinfetch) from being the same size as `<h1>`'s, and brings the font size more in line with what we have live in joinfetch right now.

/cc @underdogio/engineering 