### PR TITLE
Tweak button styling

### DIFF
--- a/styles/pup/components/_btn.scss
+++ b/styles/pup/components/_btn.scss
@@ -33,17 +33,16 @@
   display: inline-block;
   font-size: font-size(-1);
   font-weight: font-weight(bold);
-  padding: 0.75em 2em;
+  padding: 1em 2em;
   text-decoration: none;
 }
 
 .btn--primary {
-  @include btn($color-dark-green, $color-dark-green, $color-white);
+  @include btn($color-green, $color-green, $color-white);
 }
 
 .btn--secondary {
   @include btn($color-white, $color-border-dark, $color-text);
-  font-weight: font-weight(normal);
 }
 
 .btn--danger {


### PR DESCRIPTION
Makes the changes requested by @cmuir in Slack:

```
– Font weight of 600 on button text.
– Background color of #72ceaa  on buttons. Not sure where #4CC193  came from; the dark green in our color palette is #38bcac .
– Increase padding on buttons.
```

*Before*

<img width="498" alt="screen shot 2016-11-17 at 2 44 19 pm" src="https://cloud.githubusercontent.com/assets/6979137/20404776/5790c570-acd4-11e6-90de-7fab3e6a132f.png">

*After*

<img width="504" alt="screen shot 2016-11-17 at 2 43 49 pm" src="https://cloud.githubusercontent.com/assets/6979137/20404755/465c8596-acd4-11e6-911b-e0c9f923e7e3.png">


/cc @underdogio/engineering 