### PR TITLE
Change nav link hover / active color to black

### DIFF
--- a/styles/pup/components/_nav-link.scss
+++ b/styles/pup/components/_nav-link.scss
@@ -6,7 +6,7 @@
 
   &:focus,
   &:hover {
-    color: $color-text-light;
+    color: $color-black;
   }
 
   &[disabled] {
@@ -15,6 +15,6 @@
 }
 
 .nav-link--active {
-  color: $color-text-dark;
+  color: $color-black;
   font-weight: font-weight(bold);
 }


### PR DESCRIPTION
As requested by @cmuir (top link in screenshot has hover styling)

<img width="355" alt="screen shot 2016-11-17 at 2 55 59 pm" src="https://cloud.githubusercontent.com/assets/6979137/20405208/16e45e4a-acd6-11e6-99eb-2ea86da55663.png">

/cc @underdogio/engineering 