### PR TITLE
Use disc list style instead of square

### DIFF
--- a/styles/pup/helpers/_list.scss
+++ b/styles/pup/helpers/_list.scss
@@ -1,4 +1,4 @@
 .list--bullet {
-  list-style-type: square;
+  list-style-type: disc;
   padding-left: 2rem;
 }


### PR DESCRIPTION
As requested by @cmuir 

<img width="133" alt="screen shot 2016-11-17 at 3 01 03 pm" src="https://cloud.githubusercontent.com/assets/6979137/20405358/ad91bb08-acd6-11e6-8b6e-a5255b87b287.png">

/cc @underdogio/engineering 