### PR TITLE
Prevent wrapping instead of preserving whitespace in dropdowns

### DIFF
--- a/styles/pup/components/_dropdown.scss
+++ b/styles/pup/components/_dropdown.scss
@@ -19,7 +19,7 @@ $dropdown-triangle-size: 1rem;
   right: 0;
   text-align: right;
   top: 50%;
-  white-space: pre;
+  white-space: nowrap;
   width: 16rem;
   z-index: layer(dropdowns);
 


### PR DESCRIPTION
🤕 

*before*

<img width="335" alt="dropdowns - before" src="https://cloud.githubusercontent.com/assets/6979137/20406374/11adb426-acdb-11e6-8133-7b1abb5d3597.png">

*after*

<img width="317" alt="dropdowns - after" src="https://cloud.githubusercontent.com/assets/6979137/20406372/10fbb2e4-acdb-11e6-929f-aaf39b213cf4.png">

/cc @underdogio/engineering 