### PR TITLE
Render alerts above all other content

### DIFF
--- a/styles/pup/components/_alert-list.scss
+++ b/styles/pup/components/_alert-list.scss
@@ -10,6 +10,7 @@
   position: fixed;
   top: spacing(2);
   transform: translateX(-50%);
+  z-index: layer(alerts);
 }
 
 .alert-list__item {

--- a/styles/pup/variables/_layers.scss
+++ b/styles/pup/variables/_layers.scss
@@ -4,7 +4,8 @@ $layer: (
   dropdowns: 2,
   tooltips: 3,
   menu-drawer: 4,
-  modals: 5
+  modals: 5,
+  alerts: 6
 );
 @function layer($key) {
   @return map-get($layer, $key);


### PR DESCRIPTION
This will ensure that alerts are always visible, even when a model is open.

/cc @underdogio/engineering 