### PR TITLE
Remove bottom border from collapsed slabs

### DIFF
--- a/styles/pup/components/_slab.scss
+++ b/styles/pup/components/_slab.scss
@@ -29,6 +29,7 @@ $slab-padding: spacing(1);
 }
 
 .slab--collapsed {
+  border-bottom: 0;
   padding-left: spacing(half);
   padding-right: spacing(half);
 


### PR DESCRIPTION
<img width="1102" alt="underdog_io_styleguide" src="https://cloud.githubusercontent.com/assets/6979137/20544087/58914354-b0d6-11e6-9ae6-e773ea99bdd4.png">

/cc @underdogio/engineering  