### PR TITLE
Add border--thin and border--dark helper classes

### DIFF
--- a/docs/base/borders.md
+++ b/docs/base/borders.md
@@ -17,3 +17,35 @@ You can attach borders to elements with the `.border--{side}` helper classes.
     <p class="border--left">I am using `.border--left`</p>
   </div>
 </div>
+
+Add a thin border with the `.border--thin` modifier class.
+
+<div class="border border--thin">
+  <div class="padding2">
+    .border .border--thin
+  </div>
+</div>
+
+```html
+<div class="border border--thin">
+  <div class="padding2">
+    .border .border--thin
+  </div>
+</div>
+```
+
+You can also make a border dark with the `.border--dark` modifier.
+
+<div class="border border--dark">
+  <div class="padding2">
+    .border .border--dark
+  </div>
+</div>
+
+```html
+<div class="border border--dark">
+  <div class="padding2">
+    .border .border--dark
+  </div>
+</div>
+```

--- a/styles/pup/helpers/_border.scss
+++ b/styles/pup/helpers/_border.scss
@@ -7,3 +7,11 @@
     border-#{$side}: $border-width-thick solid $color-border-light;
   }
 }
+
+.border--thin {
+  border-width: $border-width-thin;
+}
+
+.border--dark {
+  border-color: $color-border-dark;
+}


### PR DESCRIPTION
For those instances when you need a border with `1px` width.

<img width="1156" alt="screen shot 2016-12-01 at 9 20 32 am" src="https://cloud.githubusercontent.com/assets/6979137/20797127/81ac687c-b7a7-11e6-90ce-709a3142dae2.png">

/cc @underdogio/engineering 