### PR TITLE
Remove max width from page headers

### DIFF
--- a/styles/pup/components/_page-header.scss
+++ b/styles/pup/components/_page-header.scss
@@ -3,7 +3,6 @@ $page-header-spacing: spacing(1);
 .page-header {
   margin-bottom: $page-header-spacing;
   margin-top: $page-header-spacing;
-  max-width: $measure-wide;
 }
 
 .page-header__title {


### PR DESCRIPTION
Closes #64 

Because we want the border to run the full length of the page, like this:

<img width="1279" alt="screen shot 2016-12-05 at 2 23 24 pm" src="https://cloud.githubusercontent.com/assets/6979137/20898986/8009721a-baf6-11e6-977c-aeac2cde1c9f.png">


/cc @underdogio/engineering 