### PR TITLE
Add .inline-center helper

### DIFF
--- a/docs/base/helpers.md
+++ b/docs/base/helpers.md
@@ -94,23 +94,23 @@ Helpers for setting an element's text color.
 
 ## Inline Center
 
-Center inline text vertically. `.inline-center` Must be applied to each piece of inline text that you want to center.
+Center inline elements vertically. `.inline-center` must be applied to the container of the elements you want centered.
 
-<div>
-  <span class="inline-center">
+<div class="inline-center">
+  <span>
     Centered
   </span>
-  <span class="inline-center" style="font-size: 0.5em">
+  <span style="font-size: 0.5em; margin-left: 0.5em">
     Vertically
   </span>
 </div>
 
 ```html
-<div>
-  <span class="inline-center">
+<div class="inline-center">
+  <span>
     Centered
   </span>
-  <span class="inline-center">
+  <span>
     Vertically
   </span>
 </div>

--- a/docs/components/dot.md
+++ b/docs/components/dot.md
@@ -11,7 +11,7 @@ category: Components
 
 ## Small dot
 
-<div class="dot dot--small"></div>
+<span class="dot dot--small"></span>
 
 ```html
 <div class="dot dot--small"></div>
@@ -19,26 +19,26 @@ category: Components
 
 ## Colored dots
 
-<div>
-  <span class="inline-center">Blue: </span>
-  <span class="dot dot--blue inline-center"></span>
+<div class="inline-center">
+  <span>Blue: </span>
+  <span class="dot dot--blue"></span>
 </div>
 
 ```html
-<div>
-  <span class="inline-center">Blue: </span>
-  <span class="dot dot--blue inline-center"></span>
+<div class="inline-center">
+  <span>Blue: </span>
+  <span class="dot dot--blue"></span>
 </div>
 ```
 
-<div>
-  <span class="inline-center">Light: </span>
-  <span class="dot dot--light inline-center"></span>
+<div class="inline-center">
+  <span>Light: </span>
+  <span class="dot dot--light"></span>
 </div>
 
 ```html
-<div>
-  <span class="inline-center">Light: </span>
-  <span class="dot dot--light inline-center"></span>
+<div class="inline-center">
+  <span>Light: </span>
+  <span class="dot dot--light"></span>
 </div>
 ```

--- a/styles/pup/_pup.scss
+++ b/styles/pup/_pup.scss
@@ -69,6 +69,7 @@
 @import 'helpers/font-weight';
 @import 'helpers/hidden';
 @import 'helpers/hide-overflow';
+@import 'helpers/inline-center';
 @import 'helpers/list';
 @import 'helpers/margin';
 @import 'helpers/opacity';

--- a/styles/pup/helpers/_inline-center.scss
+++ b/styles/pup/helpers/_inline-center.scss
@@ -1,0 +1,4 @@
+.inline-center {
+  display: inline-flex;
+  align-items: center;
+}


### PR DESCRIPTION
I'm not totally confident that this is the solution we want... more from my lack of knowledge from CSS.

```html
<div class="inline-center">
  <span>Text</span>
  <span>more text</span>
</div>
```

![image](https://cloud.githubusercontent.com/assets/1320353/20984898/2a92764c-bc90-11e6-80d2-adb9c4d44e97.png)

Although... it doesn't look all that centered to me with dots...
![image](https://cloud.githubusercontent.com/assets/1320353/20985003/8cd36226-bc90-11e6-9f0f-ec1360dddc5f.png)


Also... does this mess up the baseline for the starting text?

/cc @underdogio/engineering 