### PR TITLE
Fix up .dot's usage with a label

### DIFF
--- a/docs/base/helpers.md
+++ b/docs/base/helpers.md
@@ -99,25 +99,49 @@ Helpers for setting an element's text color.
 
 <strong class="color--red">.color--red</strong>
 
-## Inline Center
+## Inline Baseline
 
-Center inline elements vertically. `.inline-center` must be applied to the container of the elements you want centered.
+Line up inline elements vertically via the baseline. `.inline-baseline` must be applied to each child element for them to line up.
 
-<div class="inline-center">
-  <span>
+<div>
+  <span class="inline-baseline">
     Centered
   </span>
-  <span style="font-size: 0.5em; margin-left: 0.5em">
+  <span class="inline-baseline" style="font-size: 0.5em; margin-left: 0.5em">
+    Baseline
+  </span>
+</div>
+
+```html
+<div>
+  <span class="inline-baseline">
+    Centered
+  </span>
+  <span class="inline-baseline" style="font-size: 0.5em; margin-left: 0.5em">
+    Baseline
+  </span>
+</div>
+```
+
+## Inline Center
+
+Center inline elements vertically. `.inline-center` must be applied to each child element for them to line up.
+
+<div>
+  <span class="inline-center">
+    Centered
+  </span>
+  <span class="inline-center" style="font-size: 0.5em; margin-left: 0.5em">
     Vertically
   </span>
 </div>
 
 ```html
-<div class="inline-center">
-  <span>
+<div>
+  <span class="inline-center">
     Centered
   </span>
-  <span>
+  <span class="inline-center" style="font-size: 0.5em; margin-left: 0.5em">
     Vertically
   </span>
 </div>

--- a/docs/components/dot.md
+++ b/docs/components/dot.md
@@ -9,36 +9,46 @@ category: Components
 <div class="dot"></div>
 ```
 
-## Small dot
+## Dot with label
 
-<span class="dot dot--small"></span>
+<div>
+  <span class="inline-baseline">Label:&nbsp;</span>
+  <span class="dot inline-baseline"></span>
+</div>
 
 ```html
-<div class="dot dot--small"></div>
+<div>
+  <span class="inline-baseline">Label:&nbsp;</span>
+  <span class="dot inline-baseline"></span>
+</div>
 ```
 
 ## Colored dots
 
-<div class="inline-center">
-  <span>Blue: </span>
-  <span class="dot dot--blue"></span>
+<div>
+  <span class="inline-baseline">Default:&nbsp;</span>
+  <span class="dot inline-baseline"></span>
+</div>
+<div>
+  <span class="inline-baseline">Light:&nbsp;</span>
+  <span class="dot dot--light inline-baseline"></span>
+</div>
+<div>
+  <span class="inline-baseline">Blue:&nbsp;</span>
+  <span class="dot dot--blue inline-baseline"></span>
 </div>
 
 ```html
-<div class="inline-center">
-  <span>Blue: </span>
-  <span class="dot dot--blue"></span>
+<div>
+  <span class="inline-baseline">Default:&nbsp;</span>
+  <span class="dot inline-baseline"></span>
 </div>
-```
-
-<div class="inline-center">
-  <span>Light: </span>
-  <span class="dot dot--light"></span>
+<div>
+  <span class="inline-baseline">Light:&nbsp;</span>
+  <span class="dot dot--light inline-baseline"></span>
 </div>
-
-```html
-<div class="inline-center">
-  <span>Light: </span>
-  <span class="dot dot--light"></span>
+<div>
+  <span class="inline-baseline">Blue:&nbsp;</span>
+  <span class="dot dot--blue inline-baseline"></span>
 </div>
 ```

--- a/styles/pup/_pup.scss
+++ b/styles/pup/_pup.scss
@@ -69,6 +69,7 @@
 @import 'helpers/font-weight';
 @import 'helpers/hidden';
 @import 'helpers/hide-overflow';
+@import 'helpers/inline-baseline';
 @import 'helpers/inline-center';
 @import 'helpers/list';
 @import 'helpers/margin';

--- a/styles/pup/components/_dot.scss
+++ b/styles/pup/components/_dot.scss
@@ -3,11 +3,6 @@
   border-color: $color-border-dark;
   border-radius: 100%;
   display: inline-block;
-  height: 1rem;
-  width: 1rem;
-}
-
-.dot--small {
   height: 0.5rem;
   width: 0.5rem;
 }

--- a/styles/pup/helpers/_inline-baseline.scss
+++ b/styles/pup/helpers/_inline-baseline.scss
@@ -1,0 +1,4 @@
+.inline-baseline {
+  display: inline-block;
+  vertical-align: baseline;
+}

--- a/styles/pup/helpers/_inline-center.scss
+++ b/styles/pup/helpers/_inline-center.scss
@@ -1,4 +1,4 @@
 .inline-center {
-  display: inline-flex;
-  align-items: center;
+  display: inline-block;
+  vertical-align: middle;
 }


### PR DESCRIPTION

Fixes #72 
A few changes here:

* Fix `.inline-center` to actually center things
  * New changes mean we have to apply `.inline-center` on each child element, not on the parent
* Restructure how we create `.dot`s
  * This also include support for having a label, so no longer uses `.inline-center`

```html
<div class="dot">
  Label:&nbsp;
  <span class="dot__icon"></span>
</div>
```

Or as a stand alone dot with no label

```html
<div class="dot dot__icon"></div>
```

Although, I don't see too much use for them as a stand alone element... but suppose if you needed it.


### Inline center
![image](https://cloud.githubusercontent.com/assets/1320353/21110507/7481456a-c06b-11e6-82e5-f2bdce9da9d0.png)

### Dot
![image](https://cloud.githubusercontent.com/assets/1320353/21110520/82e11180-c06b-11e6-95ce-fc59bd66b894.png)



/cc @underdogio/engineering 