### PR TITLE
Make section dividers bold

### DIFF
--- a/styles/pup/components/_section-divider.scss
+++ b/styles/pup/components/_section-divider.scss
@@ -2,6 +2,7 @@
   align-items: center;
   background: $color-gray-xf3;
   display: flex;
+  font-weight: font-weight(bold);
   justify-content: space-between;
   margin: 0 0 spacing(1);
   padding: spacing(half);


### PR DESCRIPTION
So they're easier to read.

*Before*

<img width="1091" alt="screen shot 2016-12-16 at 1 49 08 pm" src="https://cloud.githubusercontent.com/assets/6979137/21274480/74e24c38-c396-11e6-8519-ae4d846a319e.png">

*After*

<img width="1094" alt="screen shot 2016-12-16 at 1 48 20 pm" src="https://cloud.githubusercontent.com/assets/6979137/21274459/53f0619a-c396-11e6-8fee-341b4c0fe2d7.png">