### PR TITLE
Fix Google web fonts import

### DIFF
--- a/styles/pup/base/_fonts.scss
+++ b/styles/pup/base/_fonts.scss
@@ -1,1 +1,0 @@
-@import 'https://fonts.googleapis.com/css?family=Open+Sans:300,400,700';

--- a/styles/pup/fonts/_open-sans.scss
+++ b/styles/pup/fonts/_open-sans.scss
@@ -1,1 +1,1 @@
-@import 'https://fonts.googleapis.com/css?family=Open+Sans:300,400,600';
+@import url('https://fonts.googleapis.com/css?family=Open+Sans:300,400,600');


### PR DESCRIPTION
Whoops, I forgot to use the `url()` function when importing Open Sans from Google web fonts.

Not sure how this was not breaking things. The only way I was able to notice that this was even a problem was when I started playing around with webpack.

# ¯\\_(ツ)_/¯

I also removed a duplicate file.