### PR TITLE
Update dark green color to #38BCAC

### DIFF
--- a/docs/base/002-colors.md
+++ b/docs/base/002-colors.md
@@ -117,10 +117,10 @@ These colors are defined in [variables/_colors.scss](https://github.com/underdog
   </div>
 
   <div class="color-block">
-    <div class="color-block__color" style="background: #4CC193"></div>
+    <div class="color-block__color" style="background: #38BCAC"></div>
     <div class="color-block__label">
       $color-dark-green<br />
-      #4CC193
+      #38BCAC
     </div>
   </div>
 

--- a/styles/pup/variables/_colors.scss
+++ b/styles/pup/variables/_colors.scss
@@ -15,7 +15,7 @@ $color-gray-222: #222222;
 $color-blue: #3497FF;
 $color-light-blue: #F5FAFF;
 $color-green: #72CEAA;
-$color-dark-green: darken($color-green, 10%);
+$color-dark-green: #38BCAC;
 $color-light-green: #ECF6F2; // Playtime
 $color-orange: #E9A631; // Sunshine
 $color-purple: #59518B;


### PR DESCRIPTION
This matches the dark green color in our logo.

*Before*

<img width="256" alt="screen shot 2017-01-26 at 1 25 01 pm" src="https://cloud.githubusercontent.com/assets/6979137/22344633/de670762-e3ca-11e6-8cc3-1720a12feafa.png">

*After*

<img width="263" alt="screen shot 2017-01-26 at 1 25 23 pm" src="https://cloud.githubusercontent.com/assets/6979137/22344638/eb61a814-e3ca-11e6-94be-103f0580af71.png">
