### PR TITLE
Use white background for tooltips

### DIFF
--- a/styles/pup/components/_tooltip.scss
+++ b/styles/pup/components/_tooltip.scss
@@ -1,13 +1,11 @@
-$tooltip-bg: $color-whitish-black;
-$tooltip-color: $color-white;
+$tooltip-bg: $color-bg;
+$tooltip-color: $color-text;
 $tooltip-font-size: font-size(-1);
-$tooltip-padding: spacing(quarter);
-$tooltip-triangle-size: 10px;
+$tooltip-padding: spacing(half);
 
 .tooltip {
   position: relative;
 
-  &:before,
   &:after {
     // Reset font styling when placed within a button
     font-size: $tooltip-font-size;
@@ -16,26 +14,17 @@ $tooltip-triangle-size: 10px;
     z-index: layer(tooltips);
   }
 
-  &:before {
-    @include triangle($tooltip-bg, $tooltip-triangle-size);
-    content: '';
-    display: inline-block;
-    left: 50%;
-    opacity: 0;
-    position: absolute;
-    top: 100%;
-    transform: translateX(-50%);
-  }
-
   &:after {
     background: $tooltip-bg;
+    border: $border-width-thin solid $color-border-dark;
     border-radius: $border-radius;
+    box-shadow: $box-shadow-light;
     color: $tooltip-color;
     content: attr(aria-label);
     display: inline-block;
+    font-weight: font-weight(normal);
     left: 50%;
-    // Make room for the triangle
-    margin-top: $tooltip-triangle-size / 2;
+    margin-top: spacing(quarter);
     opacity: 0;
     padding: $tooltip-padding;
     pointer-events: none;
@@ -46,7 +35,6 @@ $tooltip-triangle-size: 10px;
   }
 
   &:hover {
-    &:before,
     &:after {
       opacity: 1;
       pointer-events: auto;
@@ -55,7 +43,6 @@ $tooltip-triangle-size: 10px;
 }
 
 .tooltip--right {
-  &:before,
   &:after {
     left: auto;
     right: 0;
@@ -64,7 +51,6 @@ $tooltip-triangle-size: 10px;
 }
 
 .tooltip--left {
-  &:before,
   &:after {
     left: 0;
     right: auto;


### PR DESCRIPTION
Updates our tooltips to look like dis:

<img width="290" alt="screen shot 2017-01-26 at 3 45 26 pm" src="https://cloud.githubusercontent.com/assets/6979137/22349662/93a57c36-e3de-11e6-929c-1b3378fc68b7.png">
