### PR TITLE
Set display mode for icon labels to inline

### DIFF
--- a/styles/pup/base/_icons.scss
+++ b/styles/pup/base/_icons.scss
@@ -44,7 +44,7 @@
 }
 
 .icon__label {
-  display: inline-block;
+  display: inline;
   line-height: 1;
   vertical-align: middle;
 }


### PR DESCRIPTION
This will allow long labels to wrap around the icon.

"Craftsmanship"

*Before*

<img width="357" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/22384090/c40e3cde-e49a-11e6-9dfd-496b50c0d6ce.png">

*After*

<img width="357" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/22384089/c1a72b5e-e49a-11e6-9bb6-bd4160e5d6a5.png">
