### PR TITLE
Set display mode for radio and checkbox labels to 'inline

### DIFF
--- a/styles/pup/base/_forms.scss
+++ b/styles/pup/base/_forms.scss
@@ -89,7 +89,7 @@ textarea {
 .checkbox__label,
 .radio__input,
 .radio__label {
-  display: inline-block;
+  display: inline;
   line-height: 1;
   vertical-align: middle;
 }


### PR DESCRIPTION
Similar to the [issue with icons](https://github.com/underdogio/pup/pull/89), this will allow checkbox and radio input labels to wrap around the input once they get too wide to fit on a single line.

*Before*

<img width="117" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/22472801/af2d2070-e7a4-11e6-8f63-f559b0938d93.png">

*After*

<img width="106" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/22472793/aaf64b8a-e7a4-11e6-97f2-a031bf96ee68.png">
