### PR TITLE
Adjust font size and hover state for header links

### DIFF
--- a/styles/pup/components/_header.scss
+++ b/styles/pup/components/_header.scss
@@ -17,9 +17,9 @@
 
 .header__link {
   @include all-caps;
-  color: inherit;
-  font-size: font-size(-1);
-  font-weight: font-weight(normal);
+  @include transition(color);
+  color: $color-text-light;
+  font-weight: font-weight(bold);
   margin-right: spacing(1);
   position: relative;
   text-decoration: none;
@@ -37,24 +37,20 @@
     left: 0;
     opacity: 0;
     position: absolute;
-    top: calc(100% + 0.25em);
-    transform: translateY(-0.25em);
+    top: calc(100% + #{spacing(quarter)});
+    transform: translateY(#{spacing(quarter) / -2});
     width: 100%;
   }
 
+  &.header__link--active,
   &:focus,
   &:hover {
+    color: $color-text;
+
     &:after {
       opacity: 1;
       transform: translateY(0);
     }
-  }
-}
-
-.header__link--active {
-  &:after {
-    opacity: 1;
-    transform: translateY(0);
   }
 }
 


### PR DESCRIPTION
Adjustments based on designs from the [Zeps](https://app.zeplin.io/project.html#pid=578403bdac45ace6477b951a&sid=5894ee437d44040b14406caf).

*Before*

<img width="480" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/22794789/639989da-eec2-11e6-8265-a3ffcc0dd252.png">

*After*

<img width="556" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/22794794/657965ae-eec2-11e6-9a2f-011df2ba4af3.png">
