### PR TITLE
Don't fade entire slab when slab--disabled modifier is applied

### DIFF
--- a/docs/components/slab.md
+++ b/docs/components/slab.md
@@ -115,49 +115,16 @@ To highlight a slab add a modifier of `.slab--featured`. To fade out a slab add 
         <span class="slab__heading">Links</span>
         <ul>
           <li>
-            <a href="#">GitHub</a>
+            <a href="#" disabled>GitHub</a>
           </li>
         </ul>
       </div>
       <div class="slab__section col-2-large-and-up">
-        <a class="btn btn--block btn--primary btn--disabled" href="mailto:chris@underdog.io">Email</a>
+        <a class="btn btn--block btn--primary btn--disabled" href="mailto:chris@underdog.io" disabled>Email</a>
       </div>
     </div>
   </li>
   <li class="slab slab--collapsed">
-    <div class="row">
-      <div class="slab__section col-3-large-and-up">
-        <span class="slab__title">Matthew Marrone</span>
-        <span>Mobile engineer at <a href="#">Portable Technology Solutions</a></span>
-      </div>
-      <div class="slab__section col-2-large-and-up">
-        <span class="slab__heading">Desired Roles</span>
-        <span>Software engineer, Mobile developer</span>
-      </div>
-      <div class="slab__section col-3-large-and-up">
-        <span class="slab__heading">In their own words</span>
-        <span>
-          Interested in joining a small-to-medium-sized company with great teams and a good culture. I’m seeking a backend role though I’m open to other roles as well.
-        </span>
-      </div>
-      <div class="slab__section col-2-large-and-up">
-        <span class="slab__heading">Links</span>
-        <ul>
-          <li>
-            <a href="#">GitHub</a>
-          </li>
-        </ul>
-      </div>
-      <div class="slab__section col-2-large-and-up">
-        <a class="btn btn--block btn--primary btn--disabled" href="mailto:chris@underdog.io">Email</a>
-      </div>
-    </div>
-  </li>
-</ul>
-
-```html
-<ul>
-  <li class="slab">
     <div class="row">
       <div class="slab__section col-3-large-and-up">
         <span class="slab__title">Matthew Marrone</span>
@@ -186,6 +153,39 @@ To highlight a slab add a modifier of `.slab--featured`. To fade out a slab add 
       </div>
     </div>
   </li>
+</ul>
+
+```html
+<ul>
+  <li class="slab">
+    <div class="row">
+      <div class="slab__section col-3-large-and-up">
+        <span class="slab__title">Matthew Marrone</span>
+        <span>Mobile engineer at <a href="#">Portable Technology Solutions</a></span>
+      </div>
+      <div class="slab__section col-2-large-and-up">
+        <span class="slab__heading">Desired Roles</span>
+        <span>Software engineer, Mobile developer</span>
+      </div>
+      <div class="slab__section col-3-large-and-up">
+        <span class="slab__heading">In their own words</span>
+        <span>
+          Interested in joining a small-to-medium-sized company with great teams and a good culture. I’m seeking a backend role though I’m open to other roles as well.
+        </span>
+      </div>
+      <div class="slab__section col-2-large-and-up">
+        <span class="slab__heading">Links</span>
+        <ul>
+          <li>
+            <a href="#" disabled>GitHub</a>
+          </li>
+        </ul>
+      </div>
+      <div class="slab__section col-2-large-and-up">
+        <a class="btn btn--block btn--primary btn--disabled" href="mailto:chris@underdog.io" disabled>Email</a>
+      </div>
+    </div>
+  </li>
   <li class="slab slab--collapsed">
     <div class="row">
       <div class="slab__section col-3-large-and-up">
@@ -211,7 +211,7 @@ To highlight a slab add a modifier of `.slab--featured`. To fade out a slab add 
         </ul>
       </div>
       <div class="slab__section col-2-large-and-up">
-        <a class="btn btn--block btn--primary btn--disabled" href="mailto:chris@underdog.io">Email</a>
+        <a class="btn btn--block btn--primary" href="mailto:chris@underdog.io">Email</a>
       </div>
     </div>
   </li>

--- a/styles/pup/components/_slab.scss
+++ b/styles/pup/components/_slab.scss
@@ -46,8 +46,7 @@ $slab-padding: spacing(1);
 }
 
 .slab--disabled {
-  color: $color-text-light;
-  opacity: opacity(mid);
+  color: $color-gray-xdc;
 
   .slab__heading,
   .slab__title {


### PR DESCRIPTION
This causes all elements within the slab to be faded, which may not be desired (like when rendering badges). 

I can't upload screenshots because of the S3 outage, so I will share them in Slack instead.
