### PR TITLE
Darken slab--disabled text color

### DIFF
--- a/styles/pup/components/_slab.scss
+++ b/styles/pup/components/_slab.scss
@@ -46,7 +46,7 @@ $slab-padding: spacing(1);
 }
 
 .slab--disabled {
-  color: $color-gray-xdc;
+  color: $color-text-extra-light;
 
   .slab__heading,
   .slab__title {

--- a/styles/pup/helpers/_color.scss
+++ b/styles/pup/helpers/_color.scss
@@ -2,6 +2,10 @@
   color: $color-text-light;
 }
 
+.color--text-light {
+  color: $color-text-extra-light;
+}
+
 .color--blue {
   color: $color-blue;
 }

--- a/styles/pup/variables/_colors.scss
+++ b/styles/pup/variables/_colors.scss
@@ -7,6 +7,7 @@ $color-gray-xdc: #DCDCDC;
 $color-gray-xf3: #F3F3F3;
 $color-gray-xf2: #F2F2F2;
 $color-gray-xfa: #FAFAFA;
+$color-gray-aaa: #AAAAAA;
 $color-gray-777: #777777;
 $color-gray-444: #444444;
 $color-gray-222: #222222;
@@ -37,6 +38,7 @@ $color-semi-transparent-blue: rgba($color-blue, 0.05);
 // UI colors
 $color-bg: $color-white;
 $color-text-light: $color-gray-777;
+$color-text-extra-light: $color-gray-aaa;
 $color-text: $color-gray-444;
 $color-text-dark: $color-gray-222;
 $color-headings: $color-text-dark;


### PR DESCRIPTION
#DCDCDC was a bit too hard to read.

*Before*

<img width="1093" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/23437666/e1ec9c18-fddc-11e6-925d-2f375e11f520.png">

*After*

<img width="1110" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/23437662/df8f36f6-fddc-11e6-8122-13511e8480f4.png">
