### PR TITLE
1.0.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "underdog-pup",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "config": {
     "iconFontName": "underdogio-icons"
   },


### PR DESCRIPTION
Changes include:

<img width="528" alt="screen shot 2017-03-03 at 4 25 31 pm" src="https://cloud.githubusercontent.com/assets/6979137/23569610/0ca551e0-002e-11e7-9329-0134f9260975.png">
