### PR TITLE
1.0.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "underdog-pup",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "config": {
     "iconFontName": "underdogio-icons"
   },


### PR DESCRIPTION
Includes a smaller `.container--wide` max width (1200px instead of 1400px).