### PR TITLE
Set styles for icon links

### DIFF
--- a/docs/base/icons.md
+++ b/docs/base/icons.md
@@ -123,3 +123,15 @@ If the icon has no accompanying text, then <a href="https://www.w3.org/TR/wai-ar
 ```html
 <span class="icon icon-github" aria-label="github"></span>
 ```
+
+## Helpers
+
+### Using icons as a link
+
+Apply the `.icon--link` helper class for icons that are links.
+
+<a class="icon icon-graph icon--link" aria-label="graph" href="#"></a>
+
+```html
+<a class="icon icon-graph icon--link" aria-label="graph" href="#"></a>
+```

--- a/styles/pup/base/_icons.scss
+++ b/styles/pup/base/_icons.scss
@@ -61,6 +61,24 @@
   }
 }
 
+.icon--link {
+  &:before,
+  &:after {
+    @include transition(color);
+    color: initial;
+    font-weight: font-weight(normal);
+    text-decoration: none;
+  }
+
+  &:focus,
+  &:hover {
+    &:before,
+    &:after {
+      color: $color-text-extra-light;
+    }
+  }
+}
+
 // Define icons
 @include icon('arrow-right', '\EA01')
 @include icon('arrow', '\EA02')


### PR DESCRIPTION
Adds some styles to reset our default `<a />` tag styling for links with the `.icon` class applied, which are making icon links look funky.

*Before*

<img width="67" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/23664991/3788485a-0325-11e7-94fa-7b88f35e63d6.png">

*After*

<img width="72" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/23664997/3b695c34-0325-11e7-84d0-7d3e71cf8800.png">

Also adds a hover style for icon links:

*Hover style*

<img width="73" alt="hover" src="https://cloud.githubusercontent.com/assets/6979137/23665034/50bbc48c-0325-11e7-93f2-a1e930e7ae14.png">
