### PR TITLE
Add badge--light-red modifier class

### DIFF
--- a/docs/components/_badge.md
+++ b/docs/components/_badge.md
@@ -4,7 +4,11 @@ category: Components
 ---
 
 <div class="badge">3 views</div>
+<div class="marginhalf--bottom"></div>
+<div class="badge badge--light-red">3 views</div>
 
 ```html
 <div class="badge">3 views</div>
+
+<div class="badge badge--light-red">3 views</div>
 ```

--- a/styles/pup/components/_badge.scss
+++ b/styles/pup/components/_badge.scss
@@ -7,3 +7,8 @@
   font-weight: font-weight(bold);
   padding: spacing(quarter) spacing(half);
 }
+
+.badge--light-red {
+  background: $color-light-red;
+  color: $color-white;
+}


### PR DESCRIPTION
Adds an option for a badge with a light red background color.

<img width="480" alt="screen shot 2017-04-24 at 2 16 17 pm" src="https://cloud.githubusercontent.com/assets/6979137/25352042/a1227134-28f8-11e7-9d84-2deaeb270d88.png">
