### PR TITLE
Set font weight of icons

### DIFF
--- a/styles/pup/base/_icons.scss
+++ b/styles/pup/base/_icons.scss
@@ -35,6 +35,7 @@
   &:before {
     font-family: 'underdogio-icons';
     font-size: $icon-font-size;
+    font-weight: font-weight(normal);
   }
 }
 


### PR DESCRIPTION
We want to prevent icons from inheriting bold font weights from parent elements because it makes our icons look funky.