### PR TITLE
Add helper for setting color of an element to normal text color

### DIFF
--- a/docs/base/helpers.md
+++ b/docs/base/helpers.md
@@ -118,6 +118,8 @@ Helpers for setting an element's text color.
 
 <strong class="color--light-red">.color--light-red</strong>
 
+<strong class="color--text-normal">.color--text-normal</strong>
+
 ## Inline Baseline
 
 Line up inline elements vertically via the baseline. `.inline-baseline` must be applied to each child element for them to line up.

--- a/styles/pup/helpers/_color.scss
+++ b/styles/pup/helpers/_color.scss
@@ -1,3 +1,7 @@
+.color--text-normal {
+  color: $color-text;
+}
+
 .color--text-light {
   color: $color-text-light;
 }


### PR DESCRIPTION
This helper is useful if you don't want a child element to inherit its text color from its parent.