### PR TITLE
Add form-preview layout class

### DIFF
--- a/docs/layout/form-preview.md
+++ b/docs/layout/form-preview.md
@@ -1,0 +1,42 @@
+---
+title: Form Preview
+category: Layout
+---
+
+The `.form-preview` can be used to render a preview of form output.
+The preview will be displayed to the right of the form, and will appear above
+the form when the viewport gets narrow.
+
+<div class="form-preview">
+  <div class="form-preview__form">
+    <h2>Profile</h2>
+    <form>
+      <label class="block-label">Your name</label>
+      <input class="block-input" value="Bark Ruffalo" />
+    </form>
+  </div>
+  <div class="form-preview__preview">
+    <h4>Profile preview</h4>
+    <div class="card">
+      <h3>Bark Ruffalo</h3>
+    </div>
+  </div>
+</div>
+
+```html
+<div class="form-preview">
+  <div class="form-preview__form">
+    <h2>Profile</h2>
+    <form>
+      <label class="block-label">Your name</label>
+      <input class="block-input" value="Bark Ruffalo" />
+    </form>
+  </div>
+  <div class="form-preview__preview">
+    <h4>Profile preview</h4>
+    <div class="card">
+      <h3>Bark Ruffalo</h3>
+    </div>
+  </div>
+</div>
+```

--- a/styles/pup/_pup.scss
+++ b/styles/pup/_pup.scss
@@ -51,6 +51,7 @@
 
 @import 'layout/app-container';
 @import 'layout/aside-layout';
+@import 'layout/form-preview';
 @import 'layout/container';
 @import 'layout/grid';
 @import 'layout/longform';

--- a/styles/pup/layout/_form-preview.scss
+++ b/styles/pup/layout/_form-preview.scss
@@ -1,0 +1,35 @@
+.form-preview {
+  align-items: flex-start;
+  display: flex;
+  flex-wrap: nowrap;
+  justify-content: flex-start;
+}
+
+.form-preview__form,
+.form-preview__preview {
+  flex: 1 1 50%;
+}
+
+.form-preview__form {
+  padding-right: spacing(1);
+}
+
+@include media-query(large-and-down) {
+  .form-preview {
+    flex-wrap: wrap;
+  }
+
+  .form-preview__form,
+  .form-preview__preview {
+    flex-basis: 100%;
+  }
+
+  .form-preview__form {
+    padding-right: 0;
+  }
+
+  .form-preview__preview {
+    order: -1;
+    margin-bottom: spacing(1);
+  }
+}


### PR DESCRIPTION
This class can be used to render a preview of form output inline with a form.

*Extra large viewports*

<img width="946" alt="extra-large" src="https://cloud.githubusercontent.com/assets/6979137/26119754/5f6ad222-3a3c-11e7-97ec-3d2dd20ef285.png">

*Large and down*

<img width="731" alt="large-and-down" src="https://cloud.githubusercontent.com/assets/6979137/26119750/5d5c88fe-3a3c-11e7-8dfc-6763b2920854.png">
