### PR TITLE
Make header component responsive

### DIFF
--- a/docs/components/header.md
+++ b/docs/components/header.md
@@ -6,13 +6,18 @@ category: Components
 Our header is a full width header which should not be contained within a `.container`.
 To make a header sticky, apply the `.header--fixed` modifier class to it.
 
-<div class="header">
+<div class="header border--bottom">
   <div class="header__container">
-    <div class="header__left">
+    <div class="header__logo">
       <img class="hidden--small header__logo" src="/images/underdogio-logo-with-text.svg" alt="Underdog.io logo" />
       <img class="hidden--medium-and-up header__logo" src="/images/underdogio-logo.svg" alt="Underdog.io logo" />
     </div>
-    <div class="header__right">
+    <nav class="header__menu">
+      <a class="header__link" href="#">Nav link 1</a>
+      <a class="header__link" href="#">Nav link 2</a>
+      <a class="header__link" href="#">Nav link 3</a>
+    </nav>
+    <div class="header__menu-extra">
       <div class="hidden--small"><span class="icon icon-arrow icon--right icon--small"><span class="icon__label icon__label--left">Lionel Itchy</span></span></div>
       <div class="hidden--medium-and-up"><span class="icon icon-menu" aria-hidden="true"></span><span class="gamma"> Menu</span></div>
     </div>
@@ -20,17 +25,22 @@ To make a header sticky, apply the `.header--fixed` modifier class to it.
 </div>
 
 ```html
-<div class="header">
+<div class="header border--bottom">
   <div class="header__container">
-    <div class="header__left">
+    <div class="header__logo">
       <img class="hidden--small header__logo" src="/images/underdogio-logo-with-text.svg" alt="Underdog.io logo" />
       <img class="hidden--medium-and-up header__logo" src="/images/underdogio-logo.svg" alt="Underdog.io logo" />
     </div>
-    <div class="header__right">
+    <nav class="header__menu">
+      <a class="header__link" href="#">Nav link 1</a>
+      <a class="header__link" href="#">Nav link 2</a>
+      <a class="header__link" href="#">Nav link 3</a>
+      <a class="header__link" href="#">Nav link 4</a>
+    </nav>
+    <div class="header__menu-extra">
       <div class="hidden--small"><span class="icon icon-arrow icon--right icon--small"><span class="icon__label icon__label--left">Lionel Itchy</span></span></div>
       <div class="hidden--medium-and-up"><span class="icon icon-menu" aria-hidden="true"></span><span class="gamma"> Menu</span></div>
     </div>
   </div>
 </div>
-
 ```

--- a/styles/pup/components/_header.scss
+++ b/styles/pup/components/_header.scss
@@ -15,12 +15,21 @@
   height: 3.5rem;
 }
 
+.header__menu {
+  flex: 1 1 auto;
+  padding-left: spacing(2);
+  padding-right: spacing(quarter);
+}
+
 .header__link {
   @include all-caps;
   @include transition(color);
   color: $color-text-light;
+  display: inline-block;
   font-weight: font-weight(bold);
+  margin-bottom: spacing(quarter);
   margin-right: 2.5rem;
+  margin-top: spacing(quarter);
   position: relative;
   text-decoration: none;
 
@@ -70,4 +79,47 @@
   transform: translateX(-50%);
   width: 100%;
   z-index: layer(header);
+}
+
+@include media-query('large-and-down') {
+  .header__container {
+    flex-wrap: wrap;
+  }
+
+  .header__logo {
+    order: 0;
+  }
+
+  .header__link {
+    margin-left: spacing(1);
+    margin-right: spacing(1);
+  }
+
+  .header__menu-extra {
+    order: 1;
+  }
+
+  .header__menu {
+    // Display menu below logo and menu-extra
+    display: flex;
+    flex-basis: 100%;
+    justify-content: center;
+    order: 2;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: spacing(1);
+    text-align: center;
+    width: 100%;
+  }
+}
+
+@include media-query('small') {
+  .header__link {
+    margin-left: spacing(half);
+    margin-right: spacing(half);
+  }
+
+  .header__menu {
+    justify-content: space-between;
+  }
 }


### PR DESCRIPTION
Makes our header component responsive by forcing the links to right of the logo onto a new line as the viewport gets more narrow. Based on a mockup [from Zeps](https://zpl.io/ZC4sS2).

It should be noted that this is a **breaking change** because it requires a change to markup.

Example:

*Large*

<img width="928" alt="header-large" src="https://cloud.githubusercontent.com/assets/6979137/26801747/d78da976-4a0b-11e7-9566-0a3f6e828d92.png">

*Medium*

<img width="581" alt="header-medium" src="https://cloud.githubusercontent.com/assets/6979137/26801748/da2bbb3c-4a0b-11e7-85a3-376eb0bf7f7d.png">

*Small*

<img width="440" alt="header-small" src="https://cloud.githubusercontent.com/assets/6979137/26801750/dc7e5426-4a0b-11e7-9e76-b54ecd26a06d.png">
