### PR TITLE
Remove padding from sides of slab when collapsed

### DIFF
--- a/styles/pup/components/_slab.scss
+++ b/styles/pup/components/_slab.scss
@@ -62,3 +62,15 @@ $slab-padding: spacing(1);
     }
   }
 }
+
+@include media-query('medium-and-down') {
+  .slab {
+    padding-left: spacing(half);
+    padding-right: spacing(half);
+  }
+
+  .slab__section {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}


### PR DESCRIPTION
This will make the everything inside the slab look less mashed together when everything collapses onto a single column. 

*Before*

<img width="671" alt="slab-before" src="https://cloud.githubusercontent.com/assets/6979137/26804030/8bc91012-4a14-11e7-9922-fff763e7a31e.png">

*After*

<img width="648" alt="slab-after" src="https://cloud.githubusercontent.com/assets/6979137/26804003/6d33c48a-4a14-11e7-96d7-b2bd91bd85a6.png">
