### PR TITLE
Fix scroll momentum in app-container and aside-layout

### DIFF
--- a/docs/layout/app-container.md
+++ b/docs/layout/app-container.md
@@ -3,41 +3,30 @@ title: App Container
 category: Layout
 ---
 
-The `.app-container` allows you create a full screen app layout that keeps the header in view at all times but allows you to scroll the main content.
-
-The main content will stretch to fill the height of the container, minus the header, and can be scrolled if it contains more content than can fit into the height of the viewport.
-
-If `.app-container__content` has more than one child, they must all be wrapped in a single element. This is because `.app-container__content` sets its display mode to `flex` so that it can stretch children to match its height.
+The `.app-container` allows you create a full screen app layout that has a fixed header. The header will
+only be fixed for large viewport.
 
 There should be just one `.app-container` on a page, and it should always to applied to the top most node of the page layout.
 
-NOTE: The `.app-container` in this example has a restricted width and height, but by default it will match the width and height of the viewport.
-
-<div class="app-container" style="width: 100%; height: 25em;">
-  <div class="app-container__header">
+<div class="app-container" style="padding-top: 0;">
+  <div class="app-container__header" style="position: relative;">
     <div class="header">
-      <div class="header__left">
-        <img class="hidden--small" src="/images/underdogio-logo-with-text.svg" alt="Underdog.io logo" width="173" height="50">
-        <img class="hidden--medium-and-up" src="/images/underdogio-logo.svg" alt="Underdog.io logo" width="48" height="50">
-      </div>
-      <div class="header__right">
-        <span>Lionel Itchy</span>
-        <span class="icon icon-arrow" />
+      <div class="header__container">
+        <div class="header__logo">
+          <img class="hidden--small" src="/images/underdogio-logo-with-text.svg" alt="Underdog.io logo" width="173" height="50">
+          <img class="hidden--medium-and-up" src="/images/underdogio-logo.svg" alt="Underdog.io logo" width="48" height="50">
+        </div>
+        <div class="header__menu-extra">
+          <span>Lionel Itchy</span>
+          <span class="icon icon-arrow" />
+        </div>
       </div>
     </div>
   </div>
   <div class="app-container__content greybox">
-    <div>
-      <p>
-        Cursus eu quibusdam lectus itaque pulvinar, ullamco facilisi sunt, praesent placerat eaque? Minima minima sunt malesuada perferendis vero condimentum sapien, beatae eleifend debitis elementum luctus adipisci delectus iure penatibus incidunt accusamus aenean architecto dis sequi nunc! Nunc a excepteur taciti, natus sollicitudin, feugiat ante, inventore commodo sollicitudin primis delectus, fugit sunt! Felis minus ante repellat voluptas. Aliqua ornare egestas blandit vel nascetur proin expedita, ultricies maecenas. Ipsam eaque, possimus quam sit primis! Ut viverra wisi nullam temporibus ullamcorper officia morbi erat metus anim ullamcorper. Hic, nibh tortor sed quo nostrud porta accusantium impedit congue molestias. Praesent, enim quod nostrum sociosqu.
-      </p>
-      <p>
-        Nobis blanditiis quo potenti etiam aut netus facere sagittis lectus quia rutrum! Aliquid porta, numquam lacinia, duis netus voluptatum, quasi. Blanditiis molestias. Iusto magnis, laborum quos, non eros eleifend rhoncus corrupti voluptates, mattis lectus et ab euismod dui tortor facilisis? Fugit feugiat. Nibh eleifend distinctio! Omnis commodi metus! Ipsam felis sit etiam minima lacinia excepturi, cursus dolor tortor consequuntur odit, cum ea curabitur, dictumst, soluta recusandae maxime nulla! Commodo sint laboris. Condimentum, a, potenti, ultricies, elit qui perferendis, lorem labore, posuere, venenatis soluta imperdiet? Quo? Sunt, turpis tincidunt nec montes facilisis nostrud! Primis gravida rhoncus architecto? Cras, imperdiet corrupti, eius.
-      </p>
-      <p>
-        Rhoncus interdum pretium. Nunc justo? Vero hic sociis expedita, quisque semper aliqua incididunt urna, culpa rhoncus corporis dolor, aliquam officia illum? Sapien, nascetur mus. Soluta quaerat, exercitation euismod ligula consequatur. Nulla fringilla ridiculus quisquam, ultricies orci, nec error distinctio fugit, iste quasi doloribus viverra corporis risus deleniti fuga architecto magni donec suspendisse maecenas laboriosam aliquam quas! Quia risus nostrud taciti, occaecati platea repellendus laboris, etiam erat, quas at lacinia eget fusce deserunt molestie tortor necessitatibus curae vehicula sequi, doloribus suspendisse! Aut praesentium adipisci aliquip animi eu expedita torquent! Dui? Occaecat? Illo! Qui? Nisl magnis, perspiciatis porttitor? Dolor dolorem provident lacinia.
-      </p>
-    </div>
+    <p>
+      Cursus eu quibusdam lectus itaque pulvinar, ullamco facilisi sunt, praesent placerat eaque? Minima minima sunt malesuada perferendis vero condimentum sapien, beatae eleifend debitis elementum luctus adipisci delectus iure penatibus incidunt accusamus aenean architecto dis sequi nunc! Nunc a excepteur taciti, natus sollicitudin, feugiat ante, inventore commodo sollicitudin primis delectus, fugit sunt! Felis minus ante repellat voluptas. Aliqua ornare egestas blandit vel nascetur proin expedita, ultricies maecenas. Ipsam eaque, possimus quam sit primis! Ut viverra wisi nullam temporibus ullamcorper officia morbi erat metus anim ullamcorper. Hic, nibh tortor sed quo nostrud porta accusantium impedit congue molestias. Praesent, enim quod nostrum sociosqu.
+    </p>
   </div>
 </div>
 
@@ -45,20 +34,22 @@ NOTE: The `.app-container` in this example has a restricted width and height, bu
 <div class="app-container">
   <div class="app-container__header">
     <div class="header">
-      <div class="header__left">
-        <img class="hidden--small" src="/images/underdogio-logo-with-text.svg" alt="Underdog.io logo" width="173" height="50">
-        <img class="hidden--medium-and-up" src="/images/underdogio-logo.svg" alt="Underdog.io logo" width="48" height="50">
-      </div>
-      <div class="header__right">
-        <span>Lionel Itchy</span>
-        <span class="icon icon-arrow" />
+      <div class="header__container">
+        <div class="header__logo">
+          <img class="hidden--small" src="/images/underdogio-logo-with-text.svg" alt="Underdog.io logo" width="173" height="50">
+          <img class="hidden--medium-and-up" src="/images/underdogio-logo.svg" alt="Underdog.io logo" width="48" height="50">
+        </div>
+        <div class="header__menu-extra">
+          <span>Lionel Itchy</span>
+          <span class="icon icon-arrow" />
+        </div>
       </div>
     </div>
   </div>
-  <div class="app-container__content">
-    <div>
-      Wrap multiple children in a single div to prevent them all from displaying inline
-    </div>
+  <div class="app-container__content greybox">
+    <p>
+      Cursus eu quibusdam lectus itaque pulvinar, ullamco facilisi sunt, praesent placerat eaque? Minima minima sunt malesuada perferendis vero condimentum sapien, beatae eleifend debitis elementum luctus adipisci delectus iure penatibus incidunt accusamus aenean architecto dis sequi nunc! Nunc a excepteur taciti, natus sollicitudin, feugiat ante, inventore commodo sollicitudin primis delectus, fugit sunt! Felis minus ante repellat voluptas. Aliqua ornare egestas blandit vel nascetur proin expedita, ultricies maecenas. Ipsam eaque, possimus quam sit primis! Ut viverra wisi nullam temporibus ullamcorper officia morbi erat metus anim ullamcorper. Hic, nibh tortor sed quo nostrud porta accusantium impedit congue molestias. Praesent, enim quod nostrum sociosqu.
+    </p>
   </div>
 </div>
 ```

--- a/docs/layout/aside-layout.md
+++ b/docs/layout/aside-layout.md
@@ -6,141 +6,102 @@ category: Layout
 The `.aside-layout` creates a sidebar + content layout where the sidebar is always fixed in view,
 but the content is allowed to scroll independently.
 
-In order for this layout to work, `.aside-layout` must be wrapped in an element that has a set
-height, like `.app-container`.
-
-<div class="app-container" style="height: 20em; width: 100%;">
-  <div class="app-container__header border--bottom">
-    <div class="header">
-      <div class="header__left">
-        <img class="hidden--small" src="/images/underdogio-logo-with-text.svg" alt="Underdog.io logo" width="173" height="50">
-        <img class="hidden--medium-and-up" src="/images/underdogio-logo.svg" alt="Underdog.io logo" width="48" height="50">
+<div class="aside-layout">
+  <div class="aside-layout__sidebar  border--right">
+    <div class="sidebar">
+      <div class="sidebar__title">
+        Sidebar links
       </div>
-      <div class="header__right">
-        <span>Lionel Itchy</span>
-        <span class="icon icon-arrow icon--small" />
-      </div>
+      <ul class="sidebar__nav">
+        <li>
+          <a href="#">First link</a>
+        </li>
+        <li>
+          <a href="#" class="link--active">Active link</a>
+        </li>
+      </ul>
     </div>
   </div>
-  <div class="app-container__content">
-    <div class="aside-layout">
-      <div class="aside-layout__sidebar">
-        <div class="sidebar">
-          <div class="sidebar__title">
-            Sidebar links
-          </div>
-          <ul class="sidebar__nav">
-            <li>
-              <a href="#">First link</a>
-            </li>
-            <li>
-              <a href="#" class="link--active">Active link</a>
-            </li>
-          </ul>
-        </div>
-      </div>
-      <div class="aside-layout__content border--left">
-        <p>
-          Quibusdam ante volutpat curae, iure ad maxime cumque morbi! Dicta aptent alias dapibus morbi gravida sit, donec aliquam optio consectetuer delectus sodales ornare sodales, vitae! Sagittis consectetur sociosqu, feugiat impedit dignissim recusandae, ipsa nemo numquam, duis? Molestie eu aute ridiculus! Facere velit maecenas! Voluptate? Sollicitudin imperdiet, impedit vero. Animi, ut morbi, nisi voluptates aperiam! Minim quas potenti placerat varius sint, curae reiciendis reiciendis cillum morbi pharetra, mollitia fames, aperiam perspiciatis tincidunt mauris pretium similique torquent, tincidunt habitasse! Aut, ex, habitant? Accumsan. Saepe taciti dictumst, cras placerat. Sapien porttitor! Suspendisse aliqua aliquid interdum fugit culpa dictum commodi, aperiam temporibus iste hac.
-        </p>
-
-        <p>
-          Scelerisque feugiat. Nulla fusce voluptatum, per molestie scelerisque. Congue ornare nostra est? Vehicula molestias, natoque quos massa mattis, natoque repellendus urna, quibusdam, autem imperdiet? Lacinia aperiam ipsum netus. Qui incidunt leo adipiscing excepturi iste nesciunt aliquid? Class conubia, ullamco. Cubilia quidem dolore sociis consectetur dolorum minus? Ligula gravida placerat, quis? Quasi lobortis, aliquet mauris erat venenatis exercitationem fringilla? Magni consequuntur. Ullamcorper! Eleifend, minima curabitur labore, optio pellentesque porta, hymenaeos porttitor, nunc taciti! Mollitia risus consequatur senectus deleniti, cillum, venenatis dignissim, scelerisque. Laborum mollis accumsan! Leo consectetur, occaecat ab! Dolore numquam, eveniet mattis posuere, sodales consectetur, ipsa, eget mi cupidatat rhoncus.
-        </p>
-
-        <p>
-          Harum quas congue accusamus per? Diamlorem ligula rem cupidatat aliquet. Ab condimentum ullamcorper temporibus eius perferendis elementum wisi magnis incididunt? Dolorem exercitationem placeat eveniet ipsam pretium ullamco? Iaculis! Ipsa veniam nonummy cillum? Magnam lorem, praesent aspernatur. Quia nonummy quibusdam! Habitasse dapibus nascetur laboris class, nullam, tempus totam autem? Aute dignissim malesuada ornare a qui suspendisse hac, tempor, consequuntur diam veritatis, nullam eleifend tempore quis augue porro interdum habitasse condimentum cupidatat! Montes rhoncus. Corporis quos ut magna nulla leo maiores voluptates rerum eros inventore modi! Sapiente explicabo excepturi? Varius! Fermentum elementum, arcu euismod curae distinctio blandit sollicitudin malesuada praesent inceptos fugiat.
-        </p>
-      </div>
-    </div>
+  <div class="aside-layout__content">
+    <p>
+      Quibusdam ante volutpat curae, iure ad maxime cumque morbi! Dicta aptent alias dapibus morbi gravida sit, donec aliquam optio consectetuer delectus sodales ornare sodales, vitae! Sagittis consectetur sociosqu, feugiat impedit dignissim recusandae, ipsa nemo numquam, duis? Molestie eu aute ridiculus! Facere velit maecenas! Voluptate? Sollicitudin imperdiet, impedit vero. Animi, ut morbi, nisi voluptates aperiam! Minim quas potenti placerat varius sint, curae reiciendis reiciendis cillum morbi pharetra, mollitia fames, aperiam perspiciatis tincidunt mauris pretium similique torquent, tincidunt habitasse! Aut, ex, habitant? Accumsan. Saepe taciti dictumst, cras placerat. Sapien porttitor! Suspendisse aliqua aliquid interdum fugit culpa dictum commodi, aperiam temporibus iste hac.
+    </p>
   </div>
 </div>
 
 ```html
-<div class="app-container">
-  <div class="app-container__header border--bottom">
-    <div class="header">
-      <div class="header__left">
-        <img class="hidden--small" src="/images/underdogio-logo-with-text.svg" alt="Underdog.io logo" width="173" height="50">
-        <img class="hidden--medium-and-up" src="/images/underdogio-logo.svg" alt="Underdog.io logo" width="48" height="50">
+<div class="aside-layout">
+  <div class="aside-layout__sidebar border--right">
+    <div class="sidebar">
+      <div class="sidebar__title">
+        Sidebar links
       </div>
-      <div class="header__right">
-        <span>Lionel Itchy</span>
-        <span class="icon icon-arrow icon--small" />
-      </div>
+      <ul class="sidebar__nav">
+        <li>
+          <a href="#">First link</a>
+        </li>
+        <li>
+          <a href="#" class="link--active">Active link</a>
+        </li>
+      </ul>
     </div>
   </div>
-  <div class="app-container__content">
-    <div class="aside-layout">
-      <div class="aside-layout__sidebar">
-        Sidebar goes in here
-      </div>
-      <div class="aside-layout__content">
-        Content goes in here
-      </div>
-    </div>
+  <div class="aside-layout__content">
+    <p>
+      Quibusdam ante volutpat curae, iure ad maxime cumque morbi! Dicta aptent alias dapibus morbi gravida sit, donec aliquam optio consectetuer delectus sodales ornare sodales, vitae! Sagittis consectetur sociosqu, feugiat impedit dignissim recusandae, ipsa nemo numquam, duis? Molestie eu aute ridiculus! Facere velit maecenas! Voluptate? Sollicitudin imperdiet, impedit vero. Animi, ut morbi, nisi voluptates aperiam! Minim quas potenti placerat varius sint, curae reiciendis reiciendis cillum morbi pharetra, mollitia fames, aperiam perspiciatis tincidunt mauris pretium similique torquent, tincidunt habitasse! Aut, ex, habitant? Accumsan. Saepe taciti dictumst, cras placerat. Sapien porttitor! Suspendisse aliqua aliquid interdum fugit culpa dictum commodi, aperiam temporibus iste hac.
+    </p>
   </div>
 </div>
 ```
 
-You can make the sidebar a fixed with by applying the `.aside-layout__sidebar--fixed` modifier class to the sidebar.
+You can make the width of the sidebar fixed with by applying the `.aside-layout--fixed-sidebar-width` modifier class to the `.aside-layout`.
 
-<div class="app-container" style="height:20em; width: 100%;">
-  <div class="app-container__header border--bottom">
-    <div class="header">
-      <div class="header__container">
-        <div class="header__left">
-          <img class="hidden--small" src="/images/underdogio-logo-with-text.svg" alt="Underdog.io logo" width="173" height="50">
-          <img class="hidden--medium-and-up" src="/images/underdogio-logo.svg" alt="Underdog.io logo" width="48" height="50">
-        </div>
-        <div class="header__right">
-          <span>Lionel Itchy</span>
-          <span class="icon icon-arrow icon--small" />
-        </div>
+<div class="aside-layout aside-layout--fixed-sidebar-width">
+  <div class="aside-layout__sidebar  border--right">
+    <div class="sidebar">
+      <div class="sidebar__title">
+        Sidebar links
       </div>
+      <ul class="sidebar__nav">
+        <li>
+          <a href="#">First link</a>
+        </li>
+        <li>
+          <a href="#" class="link--active">Active link</a>
+        </li>
+      </ul>
     </div>
   </div>
-  <div class="app-container__content">
-    <div class="aside-layout">
-      <div class="aside-layout__sidebar aside-layout__sidebar--fixed">
-        Sidebar goes in here
-      </div>
-      <div class="aside-layout__content border--left">
-        <p>
-          Quibusdam ante volutpat curae, iure ad maxime cumque morbi! Dicta aptent alias dapibus morbi gravida sit, donec aliquam optio consectetuer delectus sodales ornare sodales, vitae! Sagittis consectetur sociosqu, feugiat impedit dignissim recusandae, ipsa nemo numquam, duis? Molestie eu aute ridiculus! Facere velit maecenas! Voluptate? Sollicitudin imperdiet, impedit vero. Animi, ut morbi, nisi voluptates aperiam! Minim quas potenti placerat varius sint, curae reiciendis reiciendis cillum morbi pharetra, mollitia fames, aperiam perspiciatis tincidunt mauris pretium similique torquent, tincidunt habitasse! Aut, ex, habitant? Accumsan. Saepe taciti dictumst, cras placerat. Sapien porttitor! Suspendisse aliqua aliquid interdum fugit culpa dictum commodi, aperiam temporibus iste hac.
-        </p>
-
-        <p>
-          Scelerisque feugiat. Nulla fusce voluptatum, per molestie scelerisque. Congue ornare nostra est? Vehicula molestias, natoque quos massa mattis, natoque repellendus urna, quibusdam, autem imperdiet? Lacinia aperiam ipsum netus. Qui incidunt leo adipiscing excepturi iste nesciunt aliquid? Class conubia, ullamco. Cubilia quidem dolore sociis consectetur dolorum minus? Ligula gravida placerat, quis? Quasi lobortis, aliquet mauris erat venenatis exercitationem fringilla? Magni consequuntur. Ullamcorper! Eleifend, minima curabitur labore, optio pellentesque porta, hymenaeos porttitor, nunc taciti! Mollitia risus consequatur senectus deleniti, cillum, venenatis dignissim, scelerisque. Laborum mollis accumsan! Leo consectetur, occaecat ab! Dolore numquam, eveniet mattis posuere, sodales consectetur, ipsa, eget mi cupidatat rhoncus.
-        </p>
-
-        <p>
-          Harum quas congue accusamus per? Diamlorem ligula rem cupidatat aliquet. Ab condimentum ullamcorper temporibus eius perferendis elementum wisi magnis incididunt? Dolorem exercitationem placeat eveniet ipsam pretium ullamco? Iaculis! Ipsa veniam nonummy cillum? Magnam lorem, praesent aspernatur. Quia nonummy quibusdam! Habitasse dapibus nascetur laboris class, nullam, tempus totam autem? Aute dignissim malesuada ornare a qui suspendisse hac, tempor, consequuntur diam veritatis, nullam eleifend tempore quis augue porro interdum habitasse condimentum cupidatat! Montes rhoncus. Corporis quos ut magna nulla leo maiores voluptates rerum eros inventore modi! Sapiente explicabo excepturi? Varius! Fermentum elementum, arcu euismod curae distinctio blandit sollicitudin malesuada praesent inceptos fugiat.
-        </p>
-      </div>
-    </div>
+  <div class="aside-layout__content">
+    <p>
+      Quibusdam ante volutpat curae, iure ad maxime cumque morbi! Dicta aptent alias dapibus morbi gravida sit, donec aliquam optio consectetuer delectus sodales ornare sodales, vitae! Sagittis consectetur sociosqu, feugiat impedit dignissim recusandae, ipsa nemo numquam, duis? Molestie eu aute ridiculus! Facere velit maecenas! Voluptate? Sollicitudin imperdiet, impedit vero. Animi, ut morbi, nisi voluptates aperiam! Minim quas potenti placerat varius sint, curae reiciendis reiciendis cillum morbi pharetra, mollitia fames, aperiam perspiciatis tincidunt mauris pretium similique torquent, tincidunt habitasse! Aut, ex, habitant? Accumsan. Saepe taciti dictumst, cras placerat. Sapien porttitor! Suspendisse aliqua aliquid interdum fugit culpa dictum commodi, aperiam temporibus iste hac.
+    </p>
   </div>
 </div>
 
 You can also nest aside layouts.
 
-<div class="aside-layout" style="height:20em; width: 100%;">
-  <aside class="aside-layout__sidebar border--right">
-    Aside-Layout 1 Sidebar
-  </aside>
-  <div class="aside-layout__content padding0">
-    <div class="aside-layout aside-layout--nested">
+<div class="aside-layout">
+  <div class="aside-layout__sidebar border--right">
+    <div class="sidebar">
+      <div class="sidebar__title">
+        Sidebar links
+      </div>
+      <ul class="sidebar__nav">
+        <li>
+          <a href="#">First link</a>
+        </li>
+        <li>
+          <a href="#" class="link--active">Active link</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div class="aside-layout__content">
+    <div class="aside-layout aside-layout--sidebar-right">
       <div class="aside-layout__content">
         <p>
           Quibusdam ante volutpat curae, iure ad maxime cumque morbi! Dicta aptent alias dapibus morbi gravida sit, donec aliquam optio consectetuer delectus sodales ornare sodales, vitae! Sagittis consectetur sociosqu, feugiat impedit dignissim recusandae, ipsa nemo numquam, duis? Molestie eu aute ridiculus! Facere velit maecenas! Voluptate? Sollicitudin imperdiet, impedit vero. Animi, ut morbi, nisi voluptates aperiam! Minim quas potenti placerat varius sint, curae reiciendis reiciendis cillum morbi pharetra, mollitia fames, aperiam perspiciatis tincidunt mauris pretium similique torquent, tincidunt habitasse! Aut, ex, habitant? Accumsan. Saepe taciti dictumst, cras placerat. Sapien porttitor! Suspendisse aliqua aliquid interdum fugit culpa dictum commodi, aperiam temporibus iste hac.
-        </p>
-
-        <p>
-          Scelerisque feugiat. Nulla fusce voluptatum, per molestie scelerisque. Congue ornare nostra est? Vehicula molestias, natoque quos massa mattis, natoque repellendus urna, quibusdam, autem imperdiet? Lacinia aperiam ipsum netus. Qui incidunt leo adipiscing excepturi iste nesciunt aliquid? Class conubia, ullamco. Cubilia quidem dolore sociis consectetur dolorum minus? Ligula gravida placerat, quis? Quasi lobortis, aliquet mauris erat venenatis exercitationem fringilla? Magni consequuntur. Ullamcorper! Eleifend, minima curabitur labore, optio pellentesque porta, hymenaeos porttitor, nunc taciti! Mollitia risus consequatur senectus deleniti, cillum, venenatis dignissim, scelerisque. Laborum mollis accumsan! Leo consectetur, occaecat ab! Dolore numquam, eveniet mattis posuere, sodales consectetur, ipsa, eget mi cupidatat rhoncus.
-        </p>
-
-        <p>
-          Harum quas congue accusamus per? Diamlorem ligula rem cupidatat aliquet. Ab condimentum ullamcorper temporibus eius perferendis elementum wisi magnis incididunt? Dolorem exercitationem placeat eveniet ipsam pretium ullamco? Iaculis! Ipsa veniam nonummy cillum? Magnam lorem, praesent aspernatur. Quia nonummy quibusdam! Habitasse dapibus nascetur laboris class, nullam, tempus totam autem? Aute dignissim malesuada ornare a qui suspendisse hac, tempor, consequuntur diam veritatis, nullam eleifend tempore quis augue porro interdum habitasse condimentum cupidatat! Montes rhoncus. Corporis quos ut magna nulla leo maiores voluptates rerum eros inventore modi! Sapiente explicabo excepturi? Varius! Fermentum elementum, arcu euismod curae distinctio blandit sollicitudin malesuada praesent inceptos fugiat.
         </p>
       </div>
       <aside class="aside-layout__sidebar border--left">
@@ -149,3 +110,35 @@ You can also nest aside layouts.
     </div>
   </div>
 </div>
+
+```html
+<div class="aside-layout">
+  <div class="aside-layout__sidebar border--right">
+    <div class="sidebar">
+      <div class="sidebar__title">
+        Sidebar links
+      </div>
+      <ul class="sidebar__nav">
+        <li>
+          <a href="#">First link</a>
+        </li>
+        <li>
+          <a href="#" class="link--active">Active link</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div class="aside-layout__content">
+    <div class="aside-layout aside-layout--sidebar-right">
+      <div class="aside-layout__content">
+        <p>
+          Quibusdam ante volutpat curae, iure ad maxime cumque morbi! Dicta aptent alias dapibus morbi gravida sit, donec aliquam optio consectetuer delectus sodales ornare sodales, vitae! Sagittis consectetur sociosqu, feugiat impedit dignissim recusandae, ipsa nemo numquam, duis? Molestie eu aute ridiculus! Facere velit maecenas! Voluptate? Sollicitudin imperdiet, impedit vero. Animi, ut morbi, nisi voluptates aperiam! Minim quas potenti placerat varius sint, curae reiciendis reiciendis cillum morbi pharetra, mollitia fames, aperiam perspiciatis tincidunt mauris pretium similique torquent, tincidunt habitasse! Aut, ex, habitant? Accumsan. Saepe taciti dictumst, cras placerat. Sapien porttitor! Suspendisse aliqua aliquid interdum fugit culpa dictum commodi, aperiam temporibus iste hac.
+        </p>
+      </div>
+      <aside class="aside-layout__sidebar border--left">
+        Aside-Layout 2 Sidebar
+      </aside>
+    </div>
+  </div>
+</div>
+```

--- a/styles/pup/_shared.scss
+++ b/styles/pup/_shared.scss
@@ -1,5 +1,6 @@
 @import 'functions/pow';
 
+@import 'variables/app-container';
 @import 'variables/borders';
 @import 'variables/border-radius';
 @import 'variables/box-shadow';

--- a/styles/pup/layout/_app-container.scss
+++ b/styles/pup/layout/_app-container.scss
@@ -1,31 +1,24 @@
-// Use to create a full screen layout that only allows the main
-// content to be scrolled.
 .app-container {
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
-  overflow-y: hidden;
-  width: 100vw;
+  display: block;
+  padding-top: $app-container-header-height;
 }
 
 .app-container__header {
-  // Don't allow the size of the header to change.
-  flex: 0 0 auto;
+  background: $color-bg;
+  left: 0;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: layer(header)
 }
 
-.app-container__content {
-  // Stretch children.
-  align-items: stretch;
-  display: flex;
-  // Stretch the height of the main content to match the height
-  // of the viewport.
-  flex: 1 1 auto;
-  // Allow main content to be scrolled.
-  overflow-y: auto;
+// Make header position;relative for smaller screens
+@include media-query('medium-and-down') {
+  .app-container {
+    padding-top: 0;
+  }
 
-  & > * {
-    // Since .app-container__content has its display mode to flex, the first child
-    // will only take up the space that it needs. We want it to take up the full width of the screen.
-    width: 100%;
+  .app-container__header {
+    position: relative;
   }
 }

--- a/styles/pup/layout/_aside-layout.scss
+++ b/styles/pup/layout/_aside-layout.scss
@@ -2,18 +2,13 @@
 // but the content is allowed to scroll independently. Works best when the parent container has a set height.
 
 $aside-layout-padding: spacing(2);
-$aside-layout-padding-medium-and-down: spacing(1);
+$aside-layout-padding-medium-and-down: spacing(2) / 2;
 $aside-layout-sidebar-width: percentage(2 / $grid-num-columns);
 $aside-layout-sidebar-fixed-width: 26rem;
 
 .aside-layout {
-  display: flex;
-  // Prevent the entire element from being scrolled.
-  overflow-y: hidden;
-}
-
-.aside-layout--nested {
-  height: 100%;
+  position: relative;
+  z-index: layer(base);
 }
 
 .aside-layout__sidebar,
@@ -26,18 +21,69 @@ $aside-layout-sidebar-fixed-width: 26rem;
 }
 
 .aside-layout__sidebar {
-  flex: 0 0 $aside-layout-sidebar-width;
+  background: $color-bg;
+  left: 0;
+  min-height: 100%;
+  position: absolute;
+  top: 0;
   overflow-y: auto;
-}
-
-.aside-layout__sidebar--fixed {
-  flex-basis: $aside-layout-sidebar-fixed-width;
-  width: $aside-layout-sidebar-fixed-width;
+  width: $aside-layout-sidebar-width;
+  z-index: 1;
 }
 
 .aside-layout__content {
-  // Allow the content to the right of the sidebar to stretch to fill the remaining space.
-  flex: 1 1 100%;
-  // Allow the content to be scrollable.
-  overflow-y: auto;
+  left: $aside-layout-sidebar-width;
+  position: relative;
+  width: calc(100% - #{$aside-layout-sidebar-width});
+  z-index: 0;
+}
+
+.aside-layout--fixed-sidebar {
+  > .aside-layout__sidebar {
+    height: 100%;
+    overflow-y: auto;
+    position: fixed;
+  }
+}
+
+.app-container {
+  .aside-layout--fixed-sidebar {
+    > .aside-layout__sidebar {
+      height: calc(100% - #{$app-container-header-height});
+      min-height: 0;
+      top: $app-container-header-height;
+    }
+  }
+}
+
+.aside-layout--fixed-sidebar-width {
+  .aside-layout__sidebar {
+    width: $aside-layout-sidebar-fixed-width
+  }
+
+  .aside-layout__content {
+    // Make room for sidebar
+    left: $aside-layout-sidebar-fixed-width;
+    width: calc(100% - #{$aside-layout-sidebar-fixed-width});
+  }
+}
+
+.aside-layout--sidebar-right {
+  .aside-layout__sidebar {
+    left: auto;
+    right: 0;
+  }
+
+  .aside-layout__content {
+    // Make room for sidebar
+    left: 0;
+    right: $aside-layout-sidebar-width;
+  }
+
+  &.aside-layout--fixed-sidebar-width {
+    .aside-layout__content {
+      // Make room for sidebar
+      right: $aside-layout-sidebar-fixed-width;
+    }
+  }
 }

--- a/styles/pup/variables/_app-container.scss
+++ b/styles/pup/variables/_app-container.scss
@@ -1,0 +1,1 @@
+$app-container-header-height: 5rem;


### PR DESCRIPTION
Closes #160 

Right now we are using flexbox in `.app-container` and `.aside-layout` in order to get a full screen app layout with fixed sidebars in headers. This is a nice approach because it allows us to get fixed headers without having to use `position: fixed` and set paddings everywhere.

Unfortunately we were doing this by setting `overflow-y` to `hidden` for `body`, and setting the height of `.app-container` to `100vh` and `overflow-y` to `auto`. This gives us the desired behavior of being able to scroll content while having the header and sidebar stay in place, but it removes scrolling momentum in mobile browsers which makes scrolling feel gross.

So this PR replaces that approach with the good old hack of using `position: fixed` and adding paddings to account for the newly fixed elements. I encourage you to clone this branch and run `npm run develop` to see it in action for yourselves.

This requires a slight change in markup to `.aside-layout` in order to work, so this is a **breaking change**.