### PR TITLE
Enable smooth scrolling for elements with vertical overflow

### DIFF
--- a/styles/pup/_shared.scss
+++ b/styles/pup/_shared.scss
@@ -21,3 +21,4 @@
 @import 'mixins/preserve-whitespace';
 @import 'mixins/transition';
 @import 'mixins/triangle';
+@import 'mixins/vertical-scroll';

--- a/styles/pup/layout/_app-container.scss
+++ b/styles/pup/layout/_app-container.scss
@@ -14,14 +14,13 @@
 }
 
 .app-container__content {
+  @include vertical-scroll;
   // Stretch children.
   align-items: stretch;
   display: flex;
   // Stretch the height of the main content to match the height
   // of the viewport.
   flex: 1 1 auto;
-  // Allow main content to be scrolled.
-  overflow-y: auto;
 
   & > * {
     // Since .app-container__content has its display mode to flex, the first child

--- a/styles/pup/layout/_aside-layout.scss
+++ b/styles/pup/layout/_aside-layout.scss
@@ -18,6 +18,7 @@ $aside-layout-sidebar-fixed-width: 26rem;
 
 .aside-layout__sidebar,
 .aside-layout__content {
+  @include vertical-scroll;
   padding: $aside-layout-padding;
 
   @include media-query('medium-and-down') {
@@ -27,7 +28,6 @@ $aside-layout-sidebar-fixed-width: 26rem;
 
 .aside-layout__sidebar {
   flex: 0 0 $aside-layout-sidebar-width;
-  overflow-y: auto;
 }
 
 .aside-layout__sidebar--fixed {
@@ -38,6 +38,4 @@ $aside-layout-sidebar-fixed-width: 26rem;
 .aside-layout__content {
   // Allow the content to the right of the sidebar to stretch to fill the remaining space.
   flex: 1 1 100%;
-  // Allow the content to be scrollable.
-  overflow-y: auto;
 }

--- a/styles/pup/mixins/_vertical-scroll.scss
+++ b/styles/pup/mixins/_vertical-scroll.scss
@@ -1,0 +1,6 @@
+// Enables vertical overflow and smooth scrolling for iOS devices.
+// Thanks CSS Tricks! https://css-tricks.com/snippets/css/momentum-scrolling-on-ios-overflow-elements/
+@mixin vertical-scroll {
+  overflow-y: scroll; /* has to be scroll, not auto */
+  -webkit-overflow-scrolling: touch;
+}


### PR DESCRIPTION
Adds back scrolling momentum to elements with a vertical overflow by setting `-webkit-overflow-scrolling: touch`. Found this trick [on CSS Tricks](https://css-tricks.com/snippets/css/momentum-scrolling-on-ios-overflow-elements/). 🙏 