### PR TITLE
Don't remove right margin for last header link for smaller viewports

### DIFF
--- a/styles/pup/components/_header.scss
+++ b/styles/pup/components/_header.scss
@@ -33,10 +33,6 @@
   position: relative;
   text-decoration: none;
 
-  &:last-child {
-    margin-right: 0;
-  }
-
   &:after {
     @include transition(opacity, transform);
     background: $color-gray-xdc;
@@ -79,6 +75,14 @@
   transform: translateX(-50%);
   width: 100%;
   z-index: layer(header);
+}
+
+@include media-query('extra-large-and-up') {
+  .header__link {
+    &:last-child {
+      margin-right: 0;
+    }
+  }
 }
 
 @include media-query('large-and-down') {


### PR DESCRIPTION
*Before*

<img width="415" alt="before" src="https://user-images.githubusercontent.com/6979137/26889738-1bf84b12-4b7d-11e7-9bf7-d29a23c8b5fa.png">

*After*

<img width="410" alt="after" src="https://user-images.githubusercontent.com/6979137/26889744-1e4c2e24-4b7d-11e7-8209-15c8a0de7e34.png">
