### PR TITLE
Reset form input appearance for mobile Safari

### DIFF
--- a/styles/pup/base/_forms.scss
+++ b/styles/pup/base/_forms.scss
@@ -8,6 +8,9 @@ $block-input-padding: 0.75rem;
 button,
 input,
 textarea {
+  // Reset input appearance for mobile Safari
+  -moz-appearance: none;
+  -webkit-appearance: none;
   font: inherit;
   line-height: inherit;
 }


### PR DESCRIPTION
*Before*

<img width="287" alt="before" src="https://user-images.githubusercontent.com/6979137/26890571-f9237cbc-4b7f-11e7-8bc6-1cab477ea782.png">

*After*

<img width="287" alt="after" src="https://user-images.githubusercontent.com/6979137/26890574-fbe11fea-4b7f-11e7-89c8-97ebf53026c9.png">
