### PR TITLE
Change color of underline for active header links to green

### DIFF
--- a/docs/components/header.md
+++ b/docs/components/header.md
@@ -13,7 +13,7 @@ To make a header sticky, apply the `.header--fixed` modifier class to it.
       <img class="hidden--medium-and-up header__logo" src="/images/underdogio-logo.svg" alt="Underdog.io logo" />
     </div>
     <nav class="header__menu">
-      <a class="header__link" href="#">Nav link 1</a>
+      <a class="header__link header__link--active" href="#">Nav link 1</a>
       <a class="header__link" href="#">Nav link 2</a>
       <a class="header__link" href="#">Nav link 3</a>
     </nav>
@@ -32,7 +32,7 @@ To make a header sticky, apply the `.header--fixed` modifier class to it.
       <img class="hidden--medium-and-up header__logo" src="/images/underdogio-logo.svg" alt="Underdog.io logo" />
     </div>
     <nav class="header__menu">
-      <a class="header__link" href="#">Nav link 1</a>
+      <a class="header__link header__link--active" href="#">Nav link 1</a>
       <a class="header__link" href="#">Nav link 2</a>
       <a class="header__link" href="#">Nav link 3</a>
       <a class="header__link" href="#">Nav link 4</a>

--- a/styles/pup/components/_header.scss
+++ b/styles/pup/components/_header.scss
@@ -38,7 +38,7 @@
   }
 
   &:after {
-    @include transition(opacity, transform);
+    @include transition(background, opacity, transform);
     background: $color-gray-xdc;
     content: '';
     display: block;
@@ -59,6 +59,12 @@
     &:after {
       opacity: 1;
       transform: translateY(0);
+    }
+  }
+
+  &.header__link--active {
+    &:after {
+      background: $color-green;
     }
   }
 }


### PR DESCRIPTION
Left link is active styling, middle is hover, and right is default.

<img width="370" alt="header links" src="https://user-images.githubusercontent.com/6979137/26890798-da6908d6-4b80-11e7-96b3-0657e43c1378.png">
