### PR TITLE
Add padding to slab instead of slab sections

### DIFF
--- a/docs/components/slab.md
+++ b/docs/components/slab.md
@@ -124,6 +124,9 @@ To highlight a slab add a modifier of `.slab--featured`. To fade out a slab add 
       </div>
     </div>
   </li>
+  <li class="slab">
+    Yet another slab.
+  </li>
   <li class="slab slab--collapsed">
     <div class="row">
       <div class="slab__section col-3-large-and-up">
@@ -185,6 +188,9 @@ To highlight a slab add a modifier of `.slab--featured`. To fade out a slab add 
         <a class="btn btn--block btn--primary btn--disabled" href="mailto:chris@underdog.io" disabled>Email</a>
       </div>
     </div>
+  </li>
+  <li class="slab">
+    Yet another slab.
   </li>
   <li class="slab slab--collapsed">
     <div class="row">

--- a/styles/pup/components/_slab.scss
+++ b/styles/pup/components/_slab.scss
@@ -1,20 +1,19 @@
 // Styles for slab sections when collapsed
 @mixin slab-section-collapsed {
   flex-basis: 100%;
-  padding: spacing(1) spacing(half);
-  padding-top: spacing(0);
+  margin-bottom: spacing(1);
+  padding: 0 spacing(half);
   width: 100%;
 
-  &:first-child {
-    padding-top: spacing(1);
+  &:last-child {
+    margin-bottom: 0;
   }
 }
 
 // SEE: slab.md
 .slab {
   border-bottom: $border-width-thick solid $color-border-light;
-  padding-left: spacing(1);
-  padding-right: spacing(1);
+  padding: spacing(1);
 }
 
 .slab__title,
@@ -35,14 +34,8 @@
   margin-bottom: spacing(quarter);
 }
 
-.slab__section {
-  padding: spacing(2);
-}
-
 .slab--collapsed {
   border-bottom: 0;
-  padding-left: spacing(half);
-  padding-right: spacing(half);
 
   .slab__section {
     @include slab-section-collapsed;


### PR DESCRIPTION
Slabs that don't contain a `.slab__section` within don't have any padding, which is gross.

Screenshot with changes from this PR:

<img width="980" alt="screen shot 2017-06-07 at 5 32 52 pm" src="https://user-images.githubusercontent.com/6979137/26902467-6344c098-4ba7-11e7-87d7-466bf8dc205d.png">
