### PR TITLE
Align slab headings

### DIFF
--- a/styles/pup/components/_slab.scss
+++ b/styles/pup/components/_slab.scss
@@ -1,19 +1,39 @@
-// Styles for slab sections when collapsed
-@mixin slab-section-collapsed {
-  flex-basis: 100%;
-  margin-bottom: spacing(1);
-  padding: 0 spacing(half);
-  width: 100%;
+// Styles for slabs when collapsed
+@mixin slab-collapsed {
+  padding: spacing(1) spacing(half);
 
-  &:last-child {
-    margin-bottom: 0;
+  .slab__title {
+    margin-top: 0;
+  }
+
+  .slab__section {
+    flex-basis: 100%;
+    margin-bottom: spacing(1);
+    padding: 0 spacing(half);
+    width: 100%;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  .slab__heading {
+    margin-top: 0;
   }
 }
 
 // SEE: slab.md
 .slab {
   border-bottom: $border-width-thick solid $color-border-light;
-  padding: spacing(1);
+  padding: spacing(2) spacing(1);
+
+  @include media-query('medium-and-down') {
+    @include slab-collapsed;
+  }
+}
+
+.slab__section {
+  padding-top: spacing(half);
 }
 
 .slab__title,
@@ -27,6 +47,7 @@
   @extend .h2;
   color: $color-text;
   margin-bottom: 0;
+  margin-top: -#{spacing(half)};
 }
 
 .slab__heading {
@@ -35,11 +56,8 @@
 }
 
 .slab--collapsed {
+  @include slab-collapsed;
   border-bottom: 0;
-
-  .slab__section {
-    @include slab-section-collapsed;
-  }
 }
 
 .slab--featured {
@@ -61,16 +79,5 @@
       // Don't override hover styles
       color: initial;
     }
-  }
-}
-
-@include media-query('medium-and-down') {
-  .slab {
-    padding-left: spacing(half);
-    padding-right: spacing(half);
-  }
-
-  .slab__section {
-    @include slab-section-collapsed;
   }
 }


### PR DESCRIPTION
Adjusts padding of the slab component so that the content below the headings of the slab of the slab are vertically aligned.

*Wide viewports*

<img width="961" alt="wide" src="https://user-images.githubusercontent.com/6979137/26937335-1617fde2-4c3f-11e7-9783-31ca9b6ee8cd.png">

*Narrow viewports*

<img width="291" alt="narrow" src="https://user-images.githubusercontent.com/6979137/26937330-12dbe3f0-4c3f-11e7-9656-b5740bd3f42d.png">
