### PR TITLE
Add dropdown--left modifier class

### DIFF
--- a/docs/components/dropdown.md
+++ b/docs/components/dropdown.md
@@ -28,8 +28,50 @@ Use to display menu items in a hidden menu.
 </div>
 </h1>
 
+<div class="dropdown dropdown--left" style="margin-bottom: 200px">
+  <div class="dropdown__menu">
+    <div class="dropdown__menu-container">
+      <span class="dropdown__menu-header">chrishasasuperlongname@underdog.io</span>
+      <div class="dropdown__menu-content">
+        <ul class="menu-list">
+          <li class="menu-list__item">
+            <a class="nav-link" href="/settings/">Settings</a>
+          </li>
+          <li class="menu-list__item">
+            <a class="nav-link" href="/support/">Support</a>
+          </li>
+          <li class="menu-list__item">
+            <a class="nav-link" href="/logout/">Log out</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
 ```html
 <div class="dropdown">
+  <div class="dropdown__menu">
+    <div class="dropdown__menu-container">
+      <span class="dropdown__menu-header">chrishasasuperlongname@underdog.io</span>
+      <div class="dropdown__menu-content">
+        <ul class="menu-list">
+          <li class="menu-list__item">
+            <a class="nav-link" href="/settings/">Settings</a>
+          </li>
+          <li class="menu-list__item">
+            <a class="nav-link" href="/support/">Support</a>
+          </li>
+          <li class="menu-list__item">
+            <a class="nav-link" href="/logout/">Log out</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="dropdown dropdown--left">
   <div class="dropdown__menu">
     <div class="dropdown__menu-container">
       <span class="dropdown__menu-header">chrishasasuperlongname@underdog.io</span>

--- a/styles/pup/components/_dropdown.scss
+++ b/styles/pup/components/_dropdown.scss
@@ -73,3 +73,23 @@ $dropdown-triangle-size: 1rem;
   display: block;
   font-weight: font-weight(bold);
 }
+
+.dropdown--left {
+  .dropdown__menu {
+    left: 0;
+    right: auto;
+
+    &:before {
+      // Magic numbers
+      top: -1px;
+      left: -75%;
+    }
+
+    &:after {
+      // Magic numbers
+      left: 13px;
+      right: auto;
+      top: 9px;
+    }
+  }
+}


### PR DESCRIPTION
Allows a dropdown menu to be rendered at the left edge of its parent instead of the right edge.

<img width="432" alt="screen shot 2017-06-08 at 3 49 56 pm" src="https://user-images.githubusercontent.com/6979137/26947860-3b44ed6e-4c62-11e7-89cf-99eeb7adfab6.png">
