### PR TITLE
Fix dropdown caret position for dropdown--left

### DIFF
--- a/styles/pup/components/_dropdown.scss
+++ b/styles/pup/components/_dropdown.scss
@@ -14,7 +14,7 @@ $dropdown-triangle-size: 1rem;
 
 .dropdown__menu {
   line-height: line-height(base);
-  margin-top: $dropdown-triangle-size;
+  margin-top: $dropdown-triangle-size * 2;
   position: absolute;
   right: 0;
   text-align: right;
@@ -31,9 +31,9 @@ $dropdown-triangle-size: 1rem;
     display: inline-block;
 
     // Magic numbers
-    margin-bottom: -0.4em;
-    margin-right: 1em;
-    position: relative;
+    position: absolute;
+    right: 14px;
+    top: -14px;
     z-index: 0;
   }
 
@@ -45,7 +45,7 @@ $dropdown-triangle-size: 1rem;
     // Magic numbers
     position: absolute;
     right: 13px;
-    top: 10px;
+    top: -12px;
     z-index: 1;
   }
 }
@@ -80,16 +80,14 @@ $dropdown-triangle-size: 1rem;
     right: auto;
 
     &:before {
-      // Magic numbers
-      top: -1px;
-      left: -75%;
+      left: 14px;
+      right: auto;
     }
 
     &:after {
       // Magic numbers
       left: 13px;
       right: auto;
-      top: 9px;
     }
   }
 }


### PR DESCRIPTION
Discovered that the positioning of the caret in dropdowns with the `.dropdown--left` class applied is off in another project. Probably because we are using `%` instead of `px`.

*Before*

<img width="215" alt="before" src="https://user-images.githubusercontent.com/6979137/26978359-4f24eee6-4cf9-11e7-8b19-a0b2e8749eb9.png">

*After*

<img width="174" alt="after" src="https://user-images.githubusercontent.com/6979137/26978398-6a7eee26-4cf9-11e7-8671-637657523523.png">
