### PR TITLE
Unfix header in app container for smaller viewports

### DIFF
--- a/styles/pup/layout/_app-container.scss
+++ b/styles/pup/layout/_app-container.scss
@@ -6,6 +6,13 @@
   height: 100vh;
   overflow-y: hidden;
   width: 100vw;
+
+  // Don't make header fixed for smaller screens
+  @include media-query('medium-and-down') {
+    display: block;
+    height: auto;
+    width: 100%;
+  }
 }
 
 .app-container__header {


### PR DESCRIPTION
This will give more screen space to the content. 