### PR TITLE
Increase page header top margin for wider viewports

### DIFF
--- a/styles/pup/components/_page-header.scss
+++ b/styles/pup/components/_page-header.scss
@@ -1,8 +1,13 @@
-$page-header-spacing: spacing(1);
+$page-header-spacing: spacing(2);
+$page-header-spacing-medium-and-down: spacing(1);
 
 .page-header {
   margin-bottom: $page-header-spacing;
   margin-top: $page-header-spacing;
+
+  @include media-query('medium-and-down') {
+    margin-top: $page-header-spacing-medium-and-down;
+  }
 }
 
 .page-header__title {


### PR DESCRIPTION
This matches up the top margin of the `.page-header` with the padding of `.aside-layout__content` so that pages that don't make use of `.aside-layout__content` will be in alignment with pages that do.