### PR TITLE
Decrease side padding of aside layout content for smaller viewports

### DIFF
--- a/styles/pup/layout/_aside-layout.scss
+++ b/styles/pup/layout/_aside-layout.scss
@@ -2,7 +2,7 @@
 // but the content is allowed to scroll independently. Works best when the parent container has a set height.
 
 $aside-layout-padding: spacing(2);
-$aside-layout-padding-medium-and-down: spacing(1);
+$aside-layout-padding-medium-and-down: spacing(1) spacing(0.5);
 $aside-layout-sidebar-width: percentage(2 / $grid-num-columns);
 $aside-layout-sidebar-fixed-width: 26rem;
 


### PR DESCRIPTION
A continuation of #178, this will match up the horizontal padding of `.aside-layout__content` to pages that don't have `.aside-layout__content` but do have a `.container`. 