### PR TITLE
Add input-prefix component

### DIFF
--- a/docs/components/input-prefix.md
+++ b/docs/components/input-prefix.md
@@ -1,0 +1,19 @@
+---
+title: Input Prefix
+category: Components
+---
+
+Add a non-selectable symbol to the beginning of an input field.
+
+<div class="input-prefix">
+  <div class="input-prefix__symbol">$</div>
+  <input class="input-prefix__input block-input" placeholder="100,000" />
+</div>
+
+
+```html
+<div class="input-prefix">
+  <div class="input-prefix__symbol">$</div>
+  <input class="input-prefix__input block-input" placeholder="100,000" />
+</div>
+```

--- a/styles/pup/_pup.scss
+++ b/styles/pup/_pup.scss
@@ -37,6 +37,7 @@
 @import 'components/header';
 @import 'components/hero';
 @import 'components/img-link';
+@import 'components/input-prefix';
 @import 'components/modal';
 @import 'components/nav-link';
 @import 'components/menu-drawer';

--- a/styles/pup/components/_input-prefix.scss
+++ b/styles/pup/components/_input-prefix.scss
@@ -1,0 +1,19 @@
+.input-prefix {
+  position: relative;
+}
+
+.input-prefix__symbol {
+  font-size: 1.1rem;
+  left: 0.75rem;
+  opacity: 0.5;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 1;
+}
+
+.input-prefix__input {
+  padding-left: 1.75rem;
+  position: relative;
+  z-index: 0;
+}


### PR DESCRIPTION
Adds a component for prepending input fields with a symbol:

<img width="972" alt="screen shot 2017-07-05 at 12 55 03 pm" src="https://user-images.githubusercontent.com/6979137/27875475-38d1f43a-6181-11e7-8347-f655e9ae7a3b.png">
