### PR TITLE
Render tooltips as a regular element instead of a pseudo element

### DIFF
--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -6,29 +6,46 @@ category: Components
 Add a tooltip to an element by adding the class `tooltip`. You can set the content of
 the tooltip by setting the `aria-label` attribute.
 
-<button class="btn btn--primary tooltip" aria-label="This is tooltip">
-  Center tooltip
-</button>
+<span class="tooltip" style="margin-bottom: 4em">
+  <button class="btn btn--primary">
+    Center tooltip
+  </button>
+  <span class="tooltip__content">This is tooltip</span>
+</span>
 
-<button class="btn btn--primary tooltip tooltip--left" aria-label="This is tooltip">
-  Left tooltip
-</button>
+<span class="tooltip tooltip--left" style="margin-bottom: 4em">
+  <button class="btn btn--primary">
+    Left tooltip
+  </button>
+  <span class="tooltip__content">This is tooltip</span>
+</span>
 
-<button class="btn btn--primary tooltip tooltip--right" aria-label="This is tooltip">
-  Right tooltip
-</button>
+<span class="tooltip tooltip--right" style="margin-bottom: 4em">
+  <button class="btn btn--primary">
+    Right tooltip
+  </button>
+  <span class="tooltip__content">This is tooltip</span>
+</span>
 
 ```html
+<span class="tooltip">
+  <button class="btn btn--primary">
+    Center tooltip
+  </button>
+  <span class="tooltip__content">This is tooltip</span>
+</span>
 
-<button class="btn btn--primary tooltip" aria-label="This is tooltip">
-  Center tooltip
-</button>
+<span class="tooltip tooltip--left">
+  <button class="btn btn--primary">
+    Left tooltip
+  </button>
+  <span class="tooltip__content">This is tooltip</span>
+</span>
 
-<button class="btn btn--primary tooltip tooltip--left" aria-label="This is tooltip">
-  Left tooltip
-</button>
-
-<button class="btn btn--primary tooltip tooltip--right" aria-label="This is tooltip">
-  Right tooltip
-</button>
+<span class="tooltip tooltip--right">
+  <button class="btn btn--primary">
+    Right tooltip
+  </button>
+  <span class="tooltip__content">This is tooltip</span>
+</span>
 ```

--- a/styles/pup/components/_tooltip.scss
+++ b/styles/pup/components/_tooltip.scss
@@ -4,46 +4,38 @@ $tooltip-font-size: font-size(-1);
 $tooltip-padding: spacing(half);
 
 .tooltip {
+  display: inline-block;
   position: relative;
+}
 
-  &:after {
-    // Reset font styling when placed within a button
-    font-size: $tooltip-font-size;
-    letter-spacing: 0;
-    text-transform: none;
-    z-index: layer(tooltips);
-  }
+.tooltip__content {
+  background: $tooltip-bg;
+  border: $border-width-thin solid $color-border-dark;
+  border-radius: $border-radius;
+  box-shadow: $box-shadow-light;
+  color: $tooltip-color;
+  display: inline-block;
+  // Reset font styling when placed within a button
+  font-size: $tooltip-font-size;
+  font-weight: font-weight(normal);
+  left: 50%;
+  letter-spacing: 0;
+  margin-top: spacing(quarter);
+  padding: $tooltip-padding;
+  position: absolute;
+  text-transform: none;
+  top: 100%;
+  transform: translateX(-50%);
+  white-space: pre;
+  z-index: layer(tooltips);
+}
 
-  &:after {
-    background: $tooltip-bg;
-    border: $border-width-thin solid $color-border-dark;
-    border-radius: $border-radius;
-    box-shadow: $box-shadow-light;
-    color: $tooltip-color;
-    content: attr(aria-label);
-    display: inline-block;
-    font-weight: font-weight(normal);
-    left: 50%;
-    margin-top: spacing(quarter);
-    opacity: 0;
-    padding: $tooltip-padding;
-    pointer-events: none;
-    position: absolute;
-    top: 100%;
-    transform: translateX(-50%);
-    white-space: pre;
-  }
-
-  &:hover {
-    &:after {
-      opacity: 1;
-      pointer-events: auto;
-    }
-  }
+.tooltip--block {
+  display: block;
 }
 
 .tooltip--right {
-  &:after {
+  .tooltip__content {
     left: auto;
     right: 0;
     transform: none;
@@ -51,7 +43,7 @@ $tooltip-padding: spacing(half);
 }
 
 .tooltip--left {
-  &:after {
+  .tooltip__content {
     left: 0;
     right: auto;
     transform: none;


### PR DESCRIPTION
We want to be able to modify tooltip styles from JavaScript, but we can't because tooltips are rendered as pseudo elements which cannot be styled via the DOM. So let's make 'em real elements! 🕺 

*P.S.:* This is a breaking change. 

![giphy](https://user-images.githubusercontent.com/6979137/27885523-4fa09dea-61a6-11e7-9561-78a533aa8f48.gif)
