### PR TITLE
Make modals more mobile friendly

### DIFF
--- a/styles/pup/components/_modal.scss
+++ b/styles/pup/components/_modal.scss
@@ -7,6 +7,10 @@
   top: 0;
   width: 100%;
   z-index: layer(modals);
+
+  @include media-query('medium-and-down') {
+    padding: spacing(half);
+  }
 }
 
 .modal__header {
@@ -28,14 +32,16 @@
 }
 
 .modal__content {
+  @include vertical-scroll;
   background: $color-white;
   border-radius: $border-radius;
   box-shadow: $box-shadow-dark;
   left: 50%;
+  max-height: 100vh;
   max-width: $measure-wide / 2;
   padding: spacing(1);
   position: relative;
   top: 50%;
   transform: translate(-50%, -50%);
-  width: 90%;
+  width: 100%;
 }


### PR DESCRIPTION
Closes #186 

Makes a few changes to modals in order to make them more mobile friendly:

1. Decreases padding around modals.
2. Allow modals to be scrollable when the content is taller than the height of the viewport.

*Before*

<img width="386" alt="before" src="https://user-images.githubusercontent.com/6979137/27887782-843b08d8-61b0-11e7-9534-9b97e74475bb.png">

*After*

<img width="410" alt="after" src="https://user-images.githubusercontent.com/6979137/27887779-82256c78-61b0-11e7-96ef-12e4de9e948e.png">
