### PR TITLE
Create wrapper element for buttons in btn group

### DIFF
--- a/docs/components/buttons.md
+++ b/docs/components/buttons.md
@@ -184,63 +184,29 @@ type of button.
 
 <div class="btn-group">
   <div class="btn-group__container">
-    <a class="btn btn--primary" href="mailto:bark@underdog.io">
-      Email
-    </a>
-    <button class="btn btn--primary btn--small">
-      <span class="icon icon-arrow icon--small">
-      </span>
-    </button>
-  </div>
-</div>
-
-<div class="btn-group">
-  <div class="btn-group__container">
-    <button class="btn btn--secondary">
-      A button
-    </button>
-    <button class="btn btn--secondary btn--small">
-      <span class="icon icon-arrow icon--small">
-      </span>
-    </button>
-  </div>
-</div>
-
-```html
-<div class="btn-group">
-  <div class="btn-group__container">
-    <a class="btn btn--primary" href="mailto:bark@underdog.io">
-      Email
-    </a>
-    <button class="btn btn--primary btn--small">
-      <span class="icon icon-arrow icon--small">
-      </span>
-    </button>
-  </div>
-</div>
-
-<div class="btn-group">
-  <div class="btn-group__container">
-    <button class="btn btn--secondary">
-      A button
-    </button>
-    <button class="btn btn--secondary btn--small">
-      <span class="icon icon-arrow icon--small">
-      </span>
-    </button>
-  </div>
-</div>
-```
-
-You can also use the `.btn--block` class on a `.btn--group`:
-
-<div style="max-width: 100%; width: 200px;">
-  <div class="btn-group btn--block">
-    <div class="btn-group__container">
+    <div class="btn-group__btn">
       <a class="btn btn--primary" href="mailto:bark@underdog.io">
         Email
       </a>
-      <button class="btn btn--primary btn--small btn-group__small">
+    </div>
+    <div class="btn-group__btn">
+      <button class="btn btn--primary btn--small">
+        <span class="icon icon-arrow icon--small">
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+
+<div class="btn-group">
+  <div class="btn-group__container">
+    <div class="btn-group__btn">
+      <button class="btn btn--secondary">
+        A button
+      </button>
+    </div>
+    <div class="btn-group__btn">
+      <button class="btn btn--secondary btn--small">
         <span class="icon icon-arrow icon--small">
         </span>
       </button>
@@ -249,15 +215,73 @@ You can also use the `.btn--block` class on a `.btn--group`:
 </div>
 
 ```html
+<div class="btn-group">
+  <div class="btn-group__container">
+    <div class="btn-group__btn">
+      <a class="btn btn--primary" href="mailto:bark@underdog.io">
+        Email
+      </a>
+    </div>
+    <div class="btn-group__btn">
+      <button class="btn btn--primary btn--small">
+        <span class="icon icon-arrow icon--small">
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+
+<div class="btn-group">
+  <div class="btn-group__container">
+    <div class="btn-group__btn">
+      <button class="btn btn--secondary">
+        A button
+      </button>
+    </div>
+    <div class="btn-group__btn">
+      <button class="btn btn--secondary btn--small">
+        <span class="icon icon-arrow icon--small">
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+```
+
+You can also use the `.btn--block` class on a `.btn--group`:
+
+<div style="max-width: 100%; width: 200px;">
+  <div class="btn-group btn--block">
+  <div class="btn-group__container">
+    <div class="btn-group__btn">
+      <a class="btn btn--primary" href="mailto:bark@underdog.io">
+        Email
+      </a>
+    </div>
+    <div class="btn-group__btn btn-group__btn-small">
+      <button class="btn btn--primary btn--small">
+        <span class="icon icon-arrow icon--small">
+        </span>
+      </button>
+    </div>
+  </div>
+  </div>
+</div>
+
+```html
 <div class="btn-group btn--block">
   <div class="btn-group__container">
-    <a class="btn btn--primary" href="mailto:bark@underdog.io">
-      Email
-    </a>
-    <button class="btn btn--primary btn--small btn-group__small">
-      <span class="icon icon-arrow icon--small">
-      </span>
-    </button>
+    <div class="btn-group__btn">
+      <a class="btn btn--primary" href="mailto:bark@underdog.io">
+        Email
+      </a>
+    </div>
+    <div class="btn-group__btn btn-group__btn-small">
+      <button class="btn btn--primary btn--small">
+        <span class="icon icon-arrow icon--small">
+        </span>
+      </button>
+    </div>
   </div>
 </div>
 ```

--- a/styles/pup/components/_btn.scss
+++ b/styles/pup/components/_btn.scss
@@ -97,44 +97,44 @@
 }
 
 .btn-group {
-  @include clearfix;
   display: inline-block;
+}
+
+// Have buttons take up full width of .btn-group container
+.btn-group__container {
+  display: flex;
+}
+
+.btn-group__btn {
+  align-items: stretch;
+  display: flex;
+  flex: 1 1 auto;
 
   .btn {
-    border-radius: 0;
     border: $border-width-thin solid $color-border-dark;
-    float: left;
+    border-radius: 0;
+    flex: 1 1 auto;
     // Normalize line-height between <button /> and <a /> elements
     line-height: inherit;
+  }
 
-    &:nth-child(n+2) {
-      // Remove left border after first button to avoid conflict with right border
-      border-left: 0;
-    }
-
-    &:first-child {
+  &:first-child {
+    .btn {
       border-bottom-left-radius: $border-radius;
       border-top-left-radius: $border-radius;
     }
+  }
 
-    &:last-child {
+  &:last-child {
+    .btn {
+      border-left: 0;
       border-bottom-right-radius: $border-radius;
       border-top-right-radius: $border-radius
     }
   }
 }
 
-// Have buttons take up full width of .btn-group container
-.btn-group__container {
-  display: flex;
-
-  // Allow each button to change width as needed
-  .btn {
-    flex: 1 1 auto;
-  }
-
-  // Helper to prevent a button from stretching
-  .btn-group__small {
-    flex: 0 0 auto;
-  }
+// Helper to prevent a button group from stretching
+.btn-group__btn-small {
+  flex: 0 0 auto;
 }


### PR DESCRIPTION
Adds a new element `.btn-group__btn` which removes the layout styles that are currently being applied to directly to buttons. 

The main reason for doing this is to have the ability to wrap buttons within another element without breaking the layout of the button group (this'll make more sense in a following PR). 