### PR TITLE
Add spacing to top and bottom of modal content

### DIFF
--- a/styles/pup/components/_modal.scss
+++ b/styles/pup/components/_modal.scss
@@ -37,7 +37,7 @@
   border-radius: $border-radius;
   box-shadow: $box-shadow-dark;
   left: 50%;
-  max-height: 100vh;
+  max-height: 100%;
   max-width: $measure-wide / 2;
   padding: spacing(1);
   position: relative;


### PR DESCRIPTION
The max height of the modal content is set to `100vh`, which is causing it to overflow past the modal's padding and leaving no spacing between the top and bottom of the modal content when the screen gets too short. So instead let's set the max height to `100%`. 

*Before*

<img width="433" alt="before" src="https://user-images.githubusercontent.com/6979137/27975609-fd772138-6330-11e7-8733-620987a9e6b5.png">

*After*

<img width="472" alt="after" src="https://user-images.githubusercontent.com/6979137/27975604-fa8053a0-6330-11e7-9f3a-78ba181db4c0.png">
