### PR TITLE
Fix tooltip content jitter when hovering

### DIFF
--- a/styles/pup/components/_tooltip.scss
+++ b/styles/pup/components/_tooltip.scss
@@ -1,5 +1,6 @@
 $tooltip-bg: $color-bg;
 $tooltip-color: $color-text;
+$tooltip-content-margin: spacing(quarter);
 $tooltip-font-size: font-size(-1);
 $tooltip-padding: spacing(half);
 
@@ -28,6 +29,18 @@ $tooltip-padding: spacing(half);
   transform: translateX(-50%);
   white-space: pre;
   z-index: layer(tooltips);
+
+  // Add pseudo element above tooltip content to prevent tooltip from
+  // disappearing when user hovers in between tooltip parent and tooltip content
+  &:after {
+    content: '';
+    display: block;
+    height: calc(#{$tooltip-content-margin} + 4px);
+    left: 0;
+    position: absolute;
+    top: calc(-#{$tooltip-content-margin} - 3px);
+    width: 100%;
+  }
 }
 
 .tooltip--block {


### PR DESCRIPTION
Right now if you hover over a tooltip and move your mouse over to the tooltip's content, the tooltip content will jitter about:

![tooltip-jitter-before](https://user-images.githubusercontent.com/6979137/28024744-8d65353e-655f-11e7-95fd-d026fd360e9e.gif)
*Oh no!*

This is happening because there is empty space in between the tooltip and tooltip content, which is causing a `mouseout` event to be fired which closes the tooltip. To get around that problem, we add a pseudo element that gets rendered between the tooltip and the tooltip content:

![tooltip-jitter-after](https://user-images.githubusercontent.com/6979137/28024832-c498e7bc-655f-11e7-861b-82f73582a51b.gif)
*Hooray!*