### PR TITLE
Replace slab--featured with slab--highlight

### DIFF
--- a/docs/components/slab.md
+++ b/docs/components/slab.md
@@ -5,7 +5,7 @@ category: Components
 
 Use to display pieces of information within a table or list.
 
-To highlight a slab add a modifier of `.slab--featured`. To fade out a slab add a modifier of `.slab--disabled`.
+To highlight a slab add a modifier of `.slab--highlight`. To fade out a slab add a modifier of `.slab--disabled`.
 
 <ul>
   <li class="slab">
@@ -66,7 +66,7 @@ To highlight a slab add a modifier of `.slab--featured`. To fade out a slab add 
       </div>
     </div>
   </li>
-  <li class="slab slab--featured">
+  <li class="slab slab--highlight">
     <div class="row">
       <div class="slab__section col-3-large-and-up">
         <span class="slab__title">Matthew Marrone</span>

--- a/styles/pup/components/_slab.scss
+++ b/styles/pup/components/_slab.scss
@@ -1,3 +1,6 @@
+// Duration of slab background color transition
+$slab-transition-duration: 3000ms;
+
 // Styles for slabs when collapsed
 @mixin slab-collapsed {
   padding: spacing(1) spacing(half);
@@ -26,6 +29,7 @@
 .slab {
   border-bottom: $border-width-thick solid $color-border-light;
   padding: spacing(2) spacing(1);
+  transition: background ease-out $slab-transition-duration;
 
   @include media-query('medium-and-down') {
     @include slab-collapsed;
@@ -60,8 +64,8 @@
   border-bottom: 0;
 }
 
-.slab--featured {
-  background: $color-semi-transparent-blue;
+.slab--highlight {
+  background: $color-semi-transparent-dark-blue;
 }
 
 .slab--disabled {

--- a/styles/pup/variables/_colors.scss
+++ b/styles/pup/variables/_colors.scss
@@ -36,6 +36,7 @@ $color-twitter-blue: #1DA1F2;
 // Transparent colors
 $color-semi-transparent-black: rgba($color-black, 0.15);
 $color-semi-transparent-blue: rgba($color-blue, 0.05);
+$color-semi-transparent-dark-blue: rgba($color-blue, 0.1);
 
 // UI colors
 $color-bg: $color-white;


### PR DESCRIPTION
Replaces our (currently unused) `.slab--featured` class with `.slab--highlight`, which has a darker background color and a more correct sounding name.

Also adds a transition for the slab background color so we get a nice animation when transitioning from being highlighted to having no highlight:

![slab-highlight](https://user-images.githubusercontent.com/6979137/28033580-aaef9ff0-657c-11e7-818d-5a10ecfa5b37.gif)
