### PR TITLE
Fix extra vertical overflow for app-container in Firefox

### DIFF
--- a/styles/pup/layout/_app-container.scss
+++ b/styles/pup/layout/_app-container.scss
@@ -3,14 +3,19 @@
 .app-container {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  height: 100%;
+  left: 0;
   overflow-y: hidden;
-  width: 100vw;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: layer(base);
 
   // Don't make header fixed for smaller screens
   @include media-query('medium-and-down') {
     display: block;
     height: auto;
+    position: relative;
     width: 100%;
   }
 }


### PR DESCRIPTION
We recently discovered an issue with our `.app-container` in Firefox, where the `body` element would have its own overflow and allow the user to scroll past the main app content.

This PR fixes that issue by making `.app-container` fixed and setting both its width and height to `100%`. This has the effect of making the height of `body` `100%`, which removes the extra scrollbar and prevents the user from being able to scroll past the main content.

I have confirmed that this does not break our other projects, and that it does not affect our mobile layout.  