### PR TITLE
Fix omnipresent scrollbars in app-container and aside-layout

### DIFF
--- a/styles/pup/mixins/_vertical-scroll.scss
+++ b/styles/pup/mixins/_vertical-scroll.scss
@@ -1,6 +1,6 @@
 // Enables vertical overflow and smooth scrolling for iOS devices.
 // Thanks CSS Tricks! https://css-tricks.com/snippets/css/momentum-scrolling-on-ios-overflow-elements/
 @mixin vertical-scroll {
-  overflow-y: scroll; /* has to be scroll, not auto */
+  overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 }


### PR DESCRIPTION
Removes ever-present scrollbars that appear randomly (mostly at night) when using `.app-container` and `.aside-layout`  by updating the `overflow-y` property for these components from `scroll` to `auto`. 

We originally set this property to `scroll` because this [CSS Tricks article](https://css-tricks.com/snippets/css/momentum-scrolling-on-ios-overflow-elements/) said it was necessary for enabling touch momentum in webkit browsers. But I have tested this in the iPad simulator and confirmed that we still get touch momentum 🕺