### PR TITLE
Add indent to checkbox labels

### DIFF
--- a/docs/base/forms.md
+++ b/docs/base/forms.md
@@ -147,6 +147,13 @@ To use a normal checkbox use the class name of `.checkbox`.
   <span class="checkbox__label">A checkbox</span>
 </label>
 
+<label class="checkbox">
+  <input class="checkbox__input" type="checkbox" />
+  <span class="checkbox__label">
+    Dolore adipisicing hic voluptas, sed! Porta? Consectetur quia, in euismod eleifend tellus, commodo laborum per! Suscipit ullamcorper animi quos ullamco quos! Possimus ut semper? Felis.
+  </span>
+</label>
+
 ```html
 <label class="checkbox">
   <input class="checkbox__input" type="checkbox" />

--- a/styles/pup/base/_forms.scss
+++ b/styles/pup/base/_forms.scss
@@ -84,7 +84,9 @@ textarea {
   min-height: $spacing-unit * 4;
 }
 
-.checkbox {
+.checkbox,
+.radio {
+  @include clearfix;
   display: block;
 }
 
@@ -92,13 +94,21 @@ textarea {
   display: inline-block;
 }
 
-.checkbox__input,
-.checkbox__label,
 .radio__input,
-.radio__label {
-  display: inline;
-  line-height: 1;
-  vertical-align: middle;
+.checkbox__input {
+  float: left;
+
+  // Align checkbox with text
+  margin-top: 6px;
+}
+
+.radio__label,
+.checkbox__label {
+  float: left;
+  margin-left: 0.75rem;
+
+  // Prevent label from being rendered underneath checkbox.
+  max-width: calc(90% - 0.75rem);
 }
 
 .checkbox__label,


### PR DESCRIPTION
Updates checkbox labels to have an indent, instead of wrapping around the checkbox.

*Before*

<img width="956" alt="before" src="https://user-images.githubusercontent.com/6979137/28580275-024d87c4-712d-11e7-8154-2b99f64ab6b3.png">

*After*

<img width="965" alt="after" src="https://user-images.githubusercontent.com/6979137/28580282-04b48472-712d-11e7-80c2-13459a69c6d4.png">