### PR TITLE
Add styles for input placeholders and invalid selects

### DIFF
--- a/docs/base/forms.md
+++ b/docs/base/forms.md
@@ -8,15 +8,15 @@ category: Base
 <form class="form" action="#">
   <label class="form-field">
     <span class="block-label">Input</span>
-    <input class="block-input" type="text" />
+    <input class="block-input" type="text" placeholder="A placeholder" />
   </label>
   <label class="form-field">
     <span class="block-label">Input</span>
-    <input class="block-input" type="text" />
+    <input class="block-input" type="text" placeholder="A placeholder" />
   </label>
   <label class="form-field">
     <span class="block-label">Input</span>
-    <input class="block-input" type="text" />
+    <input class="block-input" type="text" placeholder="A placeholder" />
   </label>
   <button class="btn btn--primary">Save</button>
 </form>
@@ -25,15 +25,15 @@ category: Base
 <form class="form" action="#">
   <label class="form-field">
     <span class="block-label">Input</span>
-    <input class="block-input" type="text" />
+    <input class="block-input" type="text" placeholder="A placeholder" />
   </label>
   <label class="form-field">
     <span class="block-label">Input</span>
-    <input class="block-input" type="text" />
+    <input class="block-input" type="text" placeholder="A placeholder" />
   </label>
   <label class="form-field">
     <span class="block-label">Input</span>
-    <input class="block-input" type="text" />
+    <input class="block-input" type="text" placeholder="A placeholder" />
   </label>
   <button class="btn btn--primary">Save</button>
 </form>
@@ -218,7 +218,8 @@ Select dropdowns will take up the full width of their container.
 
 <label class="form-field">
   <span class="block-label">Dropdown label</span>
-  <select>
+  <select required>
+    <option value="" hidden disabled selected>Select an option</option>
     <option value="1">Option 1</option>
     <option value="2">Option 2</option>
     <option value="3">Option 3</option>
@@ -227,8 +228,9 @@ Select dropdowns will take up the full width of their container.
 
 ```html
 <label class="form-field">
-  <span class="block-label">A dropdown</span>
-  <select>
+  <span class="block-label">Dropdown label</span>
+  <select required>
+    <option value="" hidden disabled selected>Select an option</option>
     <option value="1">Option 1</option>
     <option value="2">Option 2</option>
     <option value="3">Option 3</option>

--- a/styles/pup/base/_forms.scss
+++ b/styles/pup/base/_forms.scss
@@ -17,6 +17,12 @@ button {
   border: 0;
 }
 
+input {
+  &::placeholder {
+    color: $color-gray-aaa;
+  }
+}
+
 select,
 .block-input {
   @include transition(border);
@@ -53,6 +59,11 @@ select {
   &:focus,
   &:hover {
     background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PCFET0NUWVBFIHN2ZyBQVUJMSUMgIi0vL1czQy8vRFREIFNWRyAxLjEvL0VOIiAiaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkIj48c3ZnIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIHZpZXdCb3g9IjAgMCAyNSAyNSIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4bWw6c3BhY2U9InByZXNlcnZlIiBzdHlsZT0iZmlsbC1ydWxlOmV2ZW5vZGQ7Y2xpcC1ydWxlOmV2ZW5vZGQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjEuNDE0MjE7Ij48cGF0aCBpZD0iZHJvcGRvd24iIGQ9Ik0xMi40ODksMTMuNTE1bDkuMDQzLC04LjgyOGwzLjQ2OCwzLjM5MWwtOS4wMzksOC44MjhsMC4wMjEsMC4wMTlsLTMuNDcsMy4zODhsLTAuMDIsLTAuMDJsLTAuMDAyLDBsLTMuNDcxLC0zLjM5bC05LjAxOSwtOC44MDNsMy40NjksLTMuMzlsOS4wMiw4LjgwNVoiIHN0eWxlPSJmaWxsOiM3MmNlYWE7Ii8+PC9zdmc+);
+  }
+
+  &:invalid,
+  .select--empty {
+    color: $color-gray-aaa;
   }
 }
 


### PR DESCRIPTION
Adds some styles for placeholders and "invalid" (empty when the field is required) selects:

<img width="926" alt="screen shot 2017-08-17 at 6 28 58 pm" src="https://user-images.githubusercontent.com/6979137/29436553-117eda90-837a-11e7-8e20-1da20d04a6eb.png">

If we want to style placeholders for selects that aren't required for form submission, we can apply a class of `select--empty` when the select input has no value with JavaScript.

