### PR TITLE
Fix building for production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/app
 
 ARG NODE_ENV
 ENV NODE_ENV $NODE_ENV
-COPY package.json /usr/src/app/
+COPY package.json package-lock.json /usr/src/app/
 RUN NODE_ENV=development npm install
 COPY . /usr/src/app
 RUN npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /usr/src/app
 ARG NODE_ENV
 ENV NODE_ENV $NODE_ENV
 COPY package.json /usr/src/app/
-RUN npm install
+RUN NODE_ENV=development npm install
 COPY . /usr/src/app
 RUN npm run build
 


### PR DESCRIPTION
This PR fixes a few issues we're having when building for production:

1. Copies over our `package-lock.json` file before installing dependencies.
2. Forces the `NODE_ENV` environment variable to `development` before running `npm install` to ensure that dependencies that are required for building are installed.