### PR TITLE
Remove auto hyphens from preserve-whitespace helper class

### DIFF
--- a/styles/pup/mixins/_preserve-whitespace.scss
+++ b/styles/pup/mixins/_preserve-whitespace.scss
@@ -1,7 +1,4 @@
 @mixin preserve-whitespace {
-  -webkit-hyphens: auto;
-  -moz-hyphens: auto;
-  hyphens: auto;
   white-space: pre-line;
   word-break: break-word;
   word-wrap: break-word;


### PR DESCRIPTION
We decided that we don't want this anymore. 