### PR TITLE
Replace checkbox svg background image with a base64 encoded one

### DIFF
--- a/styles/pup/base/_forms.scss
+++ b/styles/pup/base/_forms.scss
@@ -162,7 +162,7 @@ textarea {
     width: $checkbox-size;
 
     &:after {
-      background-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 100 100" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.41421;"><path d="M34.357,91.176l-34.357,-34.573l16.687,-16.793l18.157,18.264l48.955,-49.25l16.201,16.301l-65.643,66.051Z" style="fill:#fff;"/></svg>');
+      background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAMAAADXqc3KAAAAsVBMVEUAAAD///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////+3mHKcAAAAOnRSTlMAAQIXGBkaLS4vMDEyMzRBQkNERkdISUpLTFZ5e32JioyNj5CRk5WWl5manJ2/1tfY2ezt7u/29/j5agQRQwAAAJ5JREFUeNqtztcSwiAURVHUxN57r7EXYoma+/8fJpNzFWTypvsJ1hlmEH+pN4z3bkijOO+ERBTzpq1cNbC99aSoseVN9kni2xvsU7ibZq8/4DN2/4ylxj6HO5LId9Wheocv4KkTqaQjKuweXBxxlX32JbvIXMhspf+ZNZc1HOWuH98khVn+vWzhusIt8h3crBgo32vXlQI6wO3KHvyHXiQZJEVtmTVjAAAAAElFTkSuQmCC);
       background-position: center;
       background-repeat: none;
       background-size: 8px 8px;


### PR DESCRIPTION
The SVG image doesn't work in Firefox. Sad.