### PR TITLE
Tweak dropdown menu box shadow

### DIFF
--- a/styles/pup/components/_dropdown.scss
+++ b/styles/pup/components/_dropdown.scss
@@ -58,7 +58,7 @@ $dropdown-triangle-size: 1rem;
   background: $color-white;
   border: $border-width-thin solid $color-border-dark;
   border-radius: $border-radius;
-  box-shadow: 0 2px 2px $color-gray-xdc;
+  box-shadow: 0 1px 4px rgba($color-black, 0.15);
   text-align: left;
 }
 


### PR DESCRIPTION
https://app.asana.com/0/318736946001593/505991752775893

*Before*

<img width="258" alt="before" src="https://user-images.githubusercontent.com/6979137/34126845-04401ed0-e409-11e7-932f-c850b7d4af48.png">

*After*

<img width="274" alt="after" src="https://user-images.githubusercontent.com/6979137/34126850-07dec7b2-e409-11e7-924f-0f89d0f13ec3.png">
