### PR TITLE
Set z-index for banner component

### DIFF
--- a/styles/pup/components/_banner.scss
+++ b/styles/pup/components/_banner.scss
@@ -3,6 +3,7 @@
   color: $color-white;
   padding: spacing(half);
   position: relative;
+  z-index: layer(header);
 
   a {
     color: inherit;


### PR DESCRIPTION
To ensure that banners are always rendered over "base level" (z-index: 0) content.