### PR TITLE
Fix checkbox whitespace when inside of a dropdown

### DIFF
--- a/styles/pup/base/_forms.scss
+++ b/styles/pup/base/_forms.scss
@@ -95,6 +95,7 @@ textarea {
 .radio {
   @include clearfix;
   display: block;
+  white-space: normal;
 }
 
 .checkbox--inline {


### PR DESCRIPTION
Fixes this unfortunate situation that's going on in the new Firefox:

<img width="1106" alt="screen shot 2018-03-08 at 1 05 30 pm" src="https://user-images.githubusercontent.com/6979137/37167999-7ad4bebe-22d1-11e8-8860-5d8209786399.png">
